### PR TITLE
Clarify naming of positions and hooks

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
@@ -79,12 +79,12 @@ public class ParticleCircle extends ParticleObject {
     }
 
     @Override
-    public void draw(ServerWorld world, int step, Vector3f pos) {
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
         float angleInterval = 360 / (float) this.amount;
         for (int i = 0; i < (this.amount / 2); i++) {
             double currRot = angleInterval * i;
             InterceptedResult<ParticleCircle, beforeCalc> modifiedPairBefore =
-                    this.interceptDrawCalcBefore(world, pos, currRot, step, this);
+                    this.interceptDrawCalcBefore(world, drawPos, currRot, step, this);
             ParticleCircle objectToUse = modifiedPairBefore.object;
             currRot = (double) (modifiedPairBefore.interceptData.getMetadata(beforeCalc.ITERATED_ROTATION));
             float x = (float) Math.sin(currRot);
@@ -98,13 +98,13 @@ public class ParticleCircle extends ParticleObject {
                     .rotateZ(objectToUse.rotation.z)
                     .rotateY(objectToUse.rotation.y)
                     .rotateX(objectToUse.rotation.x);
-            Vector3f finalPosVec = circumferenceVec.add(pos);
+            Vector3f finalPosVec = circumferenceVec.add(drawPos);
             InterceptedResult<ParticleCircle, afterCalc> modifiedPairAfter =
-                    objectToUse.interceptDrawCalcAfter(world, pos, finalPosVec, step, objectToUse);
+                    objectToUse.interceptDrawCalcAfter(world, drawPos, finalPosVec, step, objectToUse);
             finalPosVec = (Vector3f) (modifiedPairAfter.interceptData.getMetadata(afterCalc.DRAW_POSITION));
             this.drawParticle(world, finalPosVec);
         }
-        this.endDraw(world, step, pos);
+        this.endDraw(world, step, drawPos);
     }
 
     private InterceptedResult<ParticleCircle, afterCalc> interceptDrawCalcAfter(

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -226,18 +226,18 @@ public class ParticleCuboid extends ParticleObject {
     }
 
     @Override
-    public void draw(ServerWorld world, int step, Vector3f pos) {
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
         float width = size.x;
         float height = size.y;
         float depth = size.z;
-        Vector3f vertex1 = this.getVertex(width, height, depth, pos);
-        Vector3f vertex2 = this.getVertex(width, -height, -depth, pos);
-        Vector3f vertex3 = this.getVertex(-width, height, -depth, pos);
-        Vector3f vertex4 = this.getVertex(width, height, -depth, pos);
-        Vector3f vertex5 = this.getVertex(-width, -height, depth, pos);
-        Vector3f vertex6 = this.getVertex(width, -height, depth, pos);
-        Vector3f vertex7 = this.getVertex(-width, height, depth, pos);
-        Vector3f vertex8 = this.getVertex(-width, -height, -depth, pos);
+        Vector3f vertex1 = this.getVertex(width, height, depth, drawPos);
+        Vector3f vertex2 = this.getVertex(width, -height, -depth, drawPos);
+        Vector3f vertex3 = this.getVertex(-width, height, -depth, drawPos);
+        Vector3f vertex4 = this.getVertex(width, height, -depth, drawPos);
+        Vector3f vertex5 = this.getVertex(-width, -height, depth, drawPos);
+        Vector3f vertex6 = this.getVertex(width, -height, depth, drawPos);
+        Vector3f vertex7 = this.getVertex(-width, height, depth, drawPos);
+        Vector3f vertex8 = this.getVertex(-width, -height, -depth, drawPos);
 
         int bottomFaceAmount = this.amount.x;
         int topFaceAmount = this.amount.y;
@@ -281,7 +281,7 @@ public class ParticleCuboid extends ParticleObject {
             commonUtils.drawLine(objectInUse, world, vertex1, vertex4, verticalBarsAmount);
         }
         this.interceptDrawCalcAfter(world, step, objectInUse);
-        this.endDraw(world, step, pos);
+        this.endDraw(world, step, drawPos);
     }
 
     private void interceptDrawCalcAfter(

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
@@ -111,13 +111,13 @@ public class ParticleLine extends ParticleObject {
 
 
     @Override
-    public void draw(ServerWorld world, int step, Vector3f pos) {
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
         InterceptedResult<ParticleLine, ParticleLine.emptyData> modifiedBefore =
                 this.interceptDrawCalcBefore(world, step, this);
         ParticleLine objectInUse = modifiedBefore.object;
         commonUtils.drawLine(this, world, this.start, this.end, this.amount);
         this.interceptDrawCalcAfter(world, step, objectInUse);
-        this.endDraw(world, step, pos);
+        this.endDraw(world, step, drawPos);
     }
 
     private void interceptDrawCalcAfter(

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
@@ -7,9 +7,6 @@ import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
 
-import java.util.ArrayList;
-import java.util.List;
-
 
 /** The base class for any particle object. Particle objects are the things
  * that will be rendered. This can be a cube, a sphere, a 2D circle, a cat, a
@@ -24,19 +21,17 @@ import java.util.List;
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleObject {
-    protected ParticleEffect particle;
+    protected ParticleEffect particleEffect;
     protected Vector3f rotation;
-    protected int amount = 0;
+    protected int amount = 1;
 
-    public DrawInterceptor<ParticleObject, afterCalc> afterCalcsIntercept;
-    public DrawInterceptor<ParticleObject, beforeCalc> beforeCalcsIntercept;
+    public DrawInterceptor<ParticleObject, beforeCalc> beforeDraw;
+    public DrawInterceptor<ParticleObject, afterCalc> afterDraw;
 
     public enum beforeCalc {
         DRAW_POSITION
     }
     public enum afterCalc {}
-
-    private final List<Vector3f> positionBuffer = new ArrayList<>();
 
 
     /** Constructor for the particle object which is a point. It accepts as parameters
@@ -46,11 +41,11 @@ public class ParticleObject {
      *
      * @see ParticleObject#ParticleObject(ParticleObject)
      *
-     * @param particle The particle effect to use
+     * @param particleEffect The particle effect to use
      * @param rotation The rotation(IN RADIANS)
     */
-    public ParticleObject(ParticleEffect particle, Vector3f rotation) {
-        this.particle = particle;
+    public ParticleObject(ParticleEffect particleEffect, Vector3f rotation) {
+        this.particleEffect = particleEffect;
         this.setRotation(rotation);
     }
 
@@ -61,11 +56,10 @@ public class ParticleObject {
      *
      * @see ParticleObject#ParticleObject(ParticleEffect, Vector3f) 
      *
-     * @param particle The particle effect to use
+     * @param particleEffect The particle effect to use
     */
-    public ParticleObject(ParticleEffect particle) {
-        this.particle = particle;
-        this.rotation = new Vector3f(0, 0, 0);
+    public ParticleObject(ParticleEffect particleEffect) {
+        this(particleEffect, new Vector3f(0, 0, 0));
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -74,11 +68,11 @@ public class ParticleObject {
      * @param object The particle object to copy from
      */
     public ParticleObject(ParticleObject object) {
-        this.particle = object.particle;
+        this.particleEffect = object.particleEffect;
         this.rotation = object.rotation;
         this.amount = object.amount;
-        this.beforeCalcsIntercept = object.beforeCalcsIntercept;
-        this.afterCalcsIntercept = object.afterCalcsIntercept;
+        this.beforeDraw = object.beforeDraw;
+        this.afterDraw = object.afterDraw;
     }
 
     /** Sets the rotation to a new value. The rotation is calculated in radians and
@@ -104,8 +98,8 @@ public class ParticleObject {
      * @return The previously used particle
      */
     public ParticleEffect setParticleEffect(ParticleEffect particle) {
-        ParticleEffect prevParticle = this.particle;
-        this.particle = particle;
+        ParticleEffect prevParticle = this.particleEffect;
+        this.particleEffect = particle;
         return prevParticle;
     }
 
@@ -114,7 +108,7 @@ public class ParticleObject {
      * @return The currently used particle
      */
     public ParticleEffect getParticleEffect() {
-        return this.particle;
+        return this.particleEffect;
     }
 
     /** Sets the amount of particles to use for rendering the object. This
@@ -149,60 +143,45 @@ public class ParticleObject {
         return this.rotation;
     }
 
-    /** This method isn't meant to be used by the user and serves as a method for the system to use.
-     *  It calls this method to tell the object to render how it looks on every rendering step. It
-     *  supplies it with the server world, the current step and the position to draw at. And returns
-     *  nothing back. Its best practice to support the interceptors API
+    /** THIS METHOD SHOuLD NOT BE USED.
+     * <p>
+     *  This method is an internal APEL method to render the ParticleObject into the ServerWorld.
      *
      * @param world The server world instance
      * @param step The current rendering step at
-     * @param pos The position to draw at
+     * @param drawPos The position to draw at
      */
-    public void draw(ServerWorld world, int step, Vector3f pos) {
-        InterceptedResult<ParticleObject, beforeCalc> modifiedResult =
-                this.interceptDrawCalcBefore(world, pos, step, this);
-        pos = (Vector3f) modifiedResult.interceptData.getMetadata(beforeCalc.DRAW_POSITION);
-        this.drawParticle(world, pos);
-        this.interceptDrawCalcAfter(world, pos, step, this);
-        this.endDraw(world, step, pos);
+    @Deprecated
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
+        InterceptedResult<ParticleObject, beforeCalc> modifiedResult = this.doBeforeDraw(world, drawPos, step, this);
+        drawPos = (Vector3f) modifiedResult.interceptData.getMetadata(beforeCalc.DRAW_POSITION);
+        this.drawParticle(world, drawPos);
+        this.doAfterDraw(world, drawPos, step, this);
+        this.endDraw(world, step, drawPos);
     }
 
     public void endDraw(ServerWorld world, int step, Vector3f pos) {
-        /*
-        BatchParticleS2CPacket packet = new BatchParticleS2CPacket(
-                this.particle, false, this.positionBuffer.toArray(Vector3f[]::new)
-        );
-        List<ServerPlayerEntity> playerEntities = world.getPlayers();
-        for (ServerPlayerEntity serverPlayerEntity : playerEntities) {
-            if (serverPlayerEntity.getWorld() != world) continue;
-            serverPlayerEntity.networkHandler.sendPacket(packet);
-        }
-        this.positionBuffer.clear();
-        */
     }
 
     public void drawParticle(ServerWorld world, Vector3f position) {
         world.spawnParticles(
-                this.particle, position.x, position.y, position.z, 0,
+                this.particleEffect, position.x, position.y, position.z, 0,
                 0.0f, 0.0f, 0.0f, 1
         );
-        // this.positionBuffer.add(position);
     }
 
-    private InterceptedResult<ParticleObject, beforeCalc> interceptDrawCalcBefore(
-            ServerWorld world, Vector3f pos, int step, ParticleObject obj
+    private InterceptedResult<ParticleObject, beforeCalc> doBeforeDraw(
+            ServerWorld world, Vector3f drawPos, int step, ParticleObject obj
     ) {
-        InterceptData<beforeCalc> interceptData = new InterceptData<>(world, pos, step, beforeCalc.class);
-        interceptData.addMetadata(beforeCalc.DRAW_POSITION, pos);
-        if (this.beforeCalcsIntercept == null) return new InterceptedResult<>(interceptData, this);
-        return this.beforeCalcsIntercept.apply(interceptData, obj);
+        InterceptData<beforeCalc> interceptData = new InterceptData<>(world, drawPos, step, beforeCalc.class);
+        interceptData.addMetadata(beforeCalc.DRAW_POSITION, drawPos);
+        if (this.beforeDraw == null) return new InterceptedResult<>(interceptData, this);
+        return this.beforeDraw.apply(interceptData, obj);
     }
 
-    private void interceptDrawCalcAfter(
-            ServerWorld world, Vector3f pos, int step, ParticleObject obj
-    ) {
-        InterceptData<afterCalc> interceptData = new InterceptData<>(world, pos, step, afterCalc.class);
-        if (this.afterCalcsIntercept == null) return;
-        this.afterCalcsIntercept.apply(interceptData, obj);
+    private void doAfterDraw(ServerWorld world, Vector3f drawPos, int step, ParticleObject obj) {
+        InterceptData<afterCalc> interceptData = new InterceptData<>(world, drawPos, step, afterCalc.class);
+        if (this.afterDraw == null) return;
+        this.afterDraw.apply(interceptData, obj);
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleQuad.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleQuad.java
@@ -228,17 +228,17 @@ public class ParticleQuad extends ParticleObject {
     protected Vector3f getVertex4() {return this.vertex4;}
 
     @Override
-    public void draw(ServerWorld world, int step, Vector3f pos) {
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
         float rotX = this.rotation.x;
         float rotY = this.rotation.y;
         float rotZ = this.rotation.z;
         InterceptedResult<ParticleQuad, ParticleQuad.emptyData> modifiedResultBefore =
                 this.interceptDrawCalcBefore(world, step, this);
         ParticleQuad objectInUse = modifiedResultBefore.object;
-        Vector3f alteredVertex1 = objectInUse.vertex1.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(pos);
-        Vector3f alteredVertex2 = objectInUse.vertex2.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(pos);
-        Vector3f alteredVertex3 = objectInUse.vertex3.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(pos);
-        Vector3f alteredVertex4 = objectInUse.vertex4.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(pos);
+        Vector3f alteredVertex1 = objectInUse.vertex1.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(drawPos);
+        Vector3f alteredVertex2 = objectInUse.vertex2.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(drawPos);
+        Vector3f alteredVertex3 = objectInUse.vertex3.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(drawPos);
+        Vector3f alteredVertex4 = objectInUse.vertex4.rotateZ(rotZ).rotateY(rotX).rotateX(rotX).add(drawPos);
         InterceptedResult<ParticleQuad, ParticleQuad.afterCalcData> modifiedResultAfter = objectInUse.interceptDrawCalcAfter(
                 world, step, this, alteredVertex1, alteredVertex2, alteredVertex3, alteredVertex4
         );

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
@@ -217,22 +217,22 @@ public class ParticleTetrahedron extends ParticleObject{
     public Vector3f getVertex4() {return this.vertex4;}
 
     @Override
-    public void draw(ServerWorld world, int step, Vector3f pos) {
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
         InterceptedResult<ParticleTetrahedron, emptyData> modifiedBefore =
-                this.interceptDrawCalcBefore(world, step, pos, this);
+                this.interceptDrawCalcBefore(world, step, drawPos, this);
         ParticleTetrahedron objectToUse = modifiedBefore.object;
-        Vector3f vertex0 = this.vertex1.add(pos);
-        Vector3f vertex1 = this.vertex2.add(pos);
-        Vector3f vertex2 = this.vertex3.add(pos);
-        Vector3f vertex3 = this.vertex4.add(pos);
+        Vector3f vertex0 = this.vertex1.add(drawPos);
+        Vector3f vertex1 = this.vertex2.add(drawPos);
+        Vector3f vertex2 = this.vertex3.add(drawPos);
+        Vector3f vertex3 = this.vertex4.add(drawPos);
         commonUtils.drawLine(this, world, vertex0, vertex1, this.amount);
         commonUtils.drawLine(this, world, vertex0, vertex2, this.amount);
         commonUtils.drawLine(this, world, vertex0, vertex3, this.amount);
         commonUtils.drawLine(this, world, vertex1, vertex2, this.amount);
         commonUtils.drawLine(this, world, vertex1, vertex3, this.amount);
         commonUtils.drawLine(this, world, vertex2, vertex3, this.amount);
-        this.interceptDrawCalcAfter(world, step, pos, this);
-        this.endDraw(world, step, pos);
+        this.interceptDrawCalcAfter(world, step, drawPos, this);
+        this.endDraw(world, step, drawPos);
     }
 
     private InterceptedResult<ParticleTetrahedron, emptyData> interceptDrawCalcAfter(

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTorus.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTorus.java
@@ -45,7 +45,7 @@ public class ParticleTorus extends ParticleObject {
     }
 
     @Override
-    public void draw(ServerWorld world, int step, Vector3f pos) {
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
 
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
@@ -189,18 +189,18 @@ public class ParticleTriangle extends ParticleObject{
     public Vector3f getVertex3() {return this.vertex3;}
 
     @Override
-    public void draw(ServerWorld world, int step, Vector3f pos) {
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
         InterceptedResult<ParticleTriangle, emptyData> modifiedBefore =
-                this.interceptDrawCalcBefore(world, step, pos, this);
+                this.interceptDrawCalcBefore(world, step, drawPos, this);
         ParticleTriangle objectToUse = modifiedBefore.object;
-        Vector3f vertex1 = this.vertex1.add(pos);
-        Vector3f vertex2 = this.vertex2.add(pos);
-        Vector3f vertex3 = this.vertex3.add(pos);
+        Vector3f vertex1 = this.vertex1.add(drawPos);
+        Vector3f vertex2 = this.vertex2.add(drawPos);
+        Vector3f vertex3 = this.vertex3.add(drawPos);
         commonUtils.drawLine(objectToUse, world, vertex1, vertex2, objectToUse.amount);
         commonUtils.drawLine(objectToUse, world, vertex2, vertex3, objectToUse.amount);
         commonUtils.drawLine(objectToUse, world, vertex3, vertex1, objectToUse.amount);
-        this.interceptDrawCalcAfter(world, step, pos, this);
-        this.endDraw(world, step, pos);
+        this.interceptDrawCalcAfter(world, step, drawPos, this);
+        this.endDraw(world, step, drawPos);
     }
 
     private InterceptedResult<ParticleTriangle, emptyData> interceptDrawCalcAfter(


### PR DESCRIPTION
- `pos` -> `drawPos`
  - clearly indicate this is the drawing position
- `...Intercept` -> `do...`
  - shifts to active voice to describe what the method does
  - This one didn't apply through the subclasses because they're private, but I will do the rest if the name change is agreeable.
- `particle` -> `particleEffect`
  - Given the prevalence of "particle" in this mod, it's worth clarifying this one.

Throughout, I think the constructor calls could chain together to set defaults, so I've given an example in ParticleObject that eliminates repetition.  If this makes sense, I'll go through and apply this elsewhere.