### PR TITLE
Standardize ParticleObject and ParticleCombiner

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -296,11 +296,11 @@ public abstract class PathAnimatorBase {
      *
      * @param world The server world instance
      * @param step The current step in
-     * @param curr The current position
+     * @param drawPosition The planned drawing position
      * @throws SeqMissingException When it finds that there is no sequence yet allocated
      */
-    public void handleDrawingStep(ServerWorld world, int step, Vector3f curr) throws SeqMissingException {
-        Runnable func = () -> this.particle.draw(world, step, curr);
+    public void handleDrawingStep(ServerWorld world, int step, Vector3f drawPosition) throws SeqMissingException {
+        Runnable func = () -> this.particle.draw(world, step, drawPosition);
         if (this.delay == 0) {
             Apel.drawThread.submit(func);
             return;

--- a/src/main/java/net/mcbrincie/apel/lib/util/interceptor/DrawInterceptor.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/interceptor/DrawInterceptor.java
@@ -3,4 +3,8 @@ package net.mcbrincie.apel.lib.util.interceptor;
 @FunctionalInterface
 public interface DrawInterceptor<T, R extends Enum<R>> {
     InterceptedResult<T, R> apply(InterceptData<R> data, T obj);
+
+    static <T, R extends Enum<R>> DrawInterceptor<T, R> identity() {
+        return InterceptedResult::new;
+    }
 }


### PR DESCRIPTION
The previous implementation needed to allocate an `InterceptData` and `InterceptResult` for before and after interceptors.  Switching to `DrawContext` and its subclasses allows for allocating a single object per before/after interceptor, strongly-typed contextual values, and fewer generics to manage.

Note: There's no strong reason for the `DrawContext` objects to be inner classes, but it makes the most sense to me organizationally, lest we wind up with twice as many `DrawContext` classes and subclasses as `ParticleObject`s.  It's possible that some can be reused, but they're simple enough that I don't see that as a problem right now.  While the `ParticleCombiner`'s `AfterChildDrawContext` class makes no extension to the `DrawContext`, it does provide a durable type for that interceptor function to use if there are future properties added that are specific to `afterDrawChild` in the `ParticleCombiner`.

Assuming this is agreeable, I'll follow up with another PR to move each of the `ParticleObject` subclasses to this approach.