### PR TITLE
Standardize ParticleCuboid naming and structure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,10 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	
+
+	testImplementation "net.fabricmc:fabric-loader-junit:${project.loader_version}"
+	testImplementation(platform("org.junit:junit-bom:${project.junit_version}"))
+	testImplementation "org.mockito:mockito-core:${project.mockito_version}"
 }
 
 processResources {
@@ -77,4 +80,8 @@ publishing {
 		// The repositories here will be used for publishing your artifact, not for
 		// retrieving dependencies.
 	}
+}
+
+test {
+	useJUnitPlatform()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ archives_base_name=apel
 
 # Dependencies
 fabric_version=0.98.0+1.20.6
+
+# Test Dependencies
+junit_version=5.+
+mockito_version=5.+

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCuboidTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCuboidTest.java
@@ -1,0 +1,51 @@
+package net.mcbrincie.apel.lib.objects;
+
+import net.minecraft.particle.ParticleEffect;
+import org.joml.Vector3f;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class ParticleCuboidTest {
+
+    ParticleEffect mockParticleEffect;
+
+    @BeforeEach
+    void setup() {
+        this.mockParticleEffect = mock(ParticleEffect.class);
+    }
+
+    @Test
+    void setSizeWithFloat() {
+        // Given a ParticleCuboid
+        Vector3f beginningSize = new Vector3f(5.0f, 10.0f, 20.0f);
+        ParticleCuboid cuboid = new ParticleCuboid(this.mockParticleEffect, 10, beginningSize);
+
+        // When a new size is set
+        Vector3f prevSize = cuboid.setSize(12.0f);
+
+        // Then the old size is returned
+        assertEquals(beginningSize, prevSize);
+
+        // Then the new size is correct
+        assertEquals(new Vector3f(12.0f), cuboid.getSize());
+    }
+
+    @Test
+    void setSizeWithVector3f() {
+        // Given a ParticleCuboid
+        Vector3f beginningSize = new Vector3f(5.0f, 10.0f, 20.0f);
+        ParticleCuboid cuboid = new ParticleCuboid(this.mockParticleEffect, 10, beginningSize);
+
+        // When a new size is set
+        Vector3f prevSize = cuboid.setSize(new Vector3f(12.0f, 12.0f, 12.0f));
+
+        // Then the old size is returned
+        assertEquals(beginningSize, prevSize);
+
+        // Then the new size is correct
+        assertEquals(new Vector3f(12.0f), cuboid.getSize());
+    }
+}


### PR DESCRIPTION
Following up to https://github.com/GitBrincie212/Apel-Mod/pull/1:

This makes the same changes to `beforeDraw`, `afterDraw`, `particleEffect`, and `drawPos` as done to other `ParticleObject` subclasses.

Additionally, add defensive copies when constructing the cuboid so the caller can't inadvertently change the cuboid if they reuse the `Vector3f` instance.

Extract a `getSize()` method because both `setSize` methods need it, as do the new unit tests added to ensure that setting the size via `float` or via `Vector3f` have the same result.