### PR TITLE
Make ParticleObject abstract

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
@@ -104,7 +104,6 @@ public class ParticleCircle extends ParticleObject {
             finalPosVec = (Vector3f) (modifiedPairAfter.interceptData.getMetadata(afterCalc.DRAW_POSITION));
             this.drawParticle(world, finalPosVec);
         }
-        this.endDraw(world, step, drawPos);
     }
 
     private InterceptedResult<ParticleCircle, afterCalc> interceptDrawCalcAfter(

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -281,7 +281,6 @@ public class ParticleCuboid extends ParticleObject {
             commonUtils.drawLine(objectInUse, world, vertex1, vertex4, verticalBarsAmount);
         }
         this.doAfterDraw(world, step, objectInUse);
-        this.endDraw(world, step, drawPos);
     }
 
     private void doAfterDraw(ServerWorld world, int step, ParticleCuboid particleCuboid) {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
@@ -122,7 +122,6 @@ public class ParticleLine extends ParticleObject {
         ParticleLine objectInUse = modifiedBefore.object;
         commonUtils.drawLine(this, world, this.start, this.end, this.amount);
         this.doAfterDraw(world, step);
-        this.endDraw(world, step, drawPos);
     }
 
     /** Sets the interceptor to run after drawing the line.  The interceptor will be provided
@@ -131,7 +130,6 @@ public class ParticleLine extends ParticleObject {
      *
      * @param afterDraw the new interceptor to execute after drawing the line
      */
-    @Override
     public void setAfterDraw(DrawInterceptor<ParticleLine, AfterDrawData> afterDraw) {
         this.afterDraw = afterDraw;
     }
@@ -148,7 +146,6 @@ public class ParticleLine extends ParticleObject {
      *
      * @param beforeDraw the new interceptor to execute before drawing the line
      */
-    @Override
     public void setBeforeDraw(DrawInterceptor<ParticleLine, BeforeDrawData> beforeDraw) {
         this.beforeDraw = beforeDraw;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePoint.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePoint.java
@@ -1,0 +1,107 @@
+package net.mcbrincie.apel.lib.objects;
+
+import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
+import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
+import net.minecraft.particle.ParticleEffect;
+import net.minecraft.server.world.ServerWorld;
+import org.joml.Vector3f;
+
+/** The particle object class that represents a single point.
+ * <br>
+ * Rotation and amount have no effect on this subclass.  While mods could
+ * simply call {@link ServerWorld#spawnParticles(ParticleEffect, double, double, double, int, double, double, double, double)},
+ * providing this class allows developers to incorporate individual particles
+ * into more complex animations.
+ */
+@SuppressWarnings({"unused", "UnusedReturnValue"})
+public class ParticlePoint extends ParticleObject {
+    private Vector3f offset;
+
+    private DrawInterceptor<ParticlePoint, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+    private DrawInterceptor<ParticlePoint, AfterDrawData> afterDraw = DrawInterceptor.identity();
+
+    public enum BeforeDrawData {}
+    public enum AfterDrawData {}
+
+    /** Constructor for the particle point.  It accepts a particle to use.
+     * <br>
+     * @param particleEffect The particle to use
+     *
+     * @see ParticlePoint#ParticlePoint(ParticleEffect, Vector3f)
+     */
+    public ParticlePoint(ParticleEffect particleEffect) {
+        this(particleEffect, new Vector3f(0));
+    }
+
+    /** Constructor for the particle point.  It accepts a particle to use and the offset
+     * at which to render.
+     * <br>
+     * @param particleEffect The particle to use
+     * @param offset The offset from the draw position
+     *
+     * @see ParticlePoint#ParticlePoint(ParticleEffect)
+     */
+    public ParticlePoint(ParticleEffect particleEffect, Vector3f offset) {
+        super(particleEffect);
+        // Defensive copy to prevent inadvertent access
+        this.offset = new Vector3f(offset);
+    }
+
+    /** Gets the offset vector
+     *
+     * @return a copy of the offset vector
+     */
+    public Vector3f getOffset() {
+        // Defensive copy to prevent leaking the private instance member
+        return new Vector3f(this.offset);
+    }
+
+    /** Sets the new offset vector and returns the previous value.
+     *
+     * @param offset the new offset vector
+     * @return the previous offset vector
+     */
+    public Vector3f setOffset(Vector3f offset) {
+        Vector3f prevOffset = this.offset;
+        this.offset = offset;
+        return prevOffset;
+    }
+
+    @Override
+    public void draw(ServerWorld world, int step, Vector3f drawPos) {
+        this.doBeforeDraw(world, step);
+        Vector3f actualPosition = new Vector3f(drawPos).add(this.offset);
+        this.drawParticle(world, actualPosition);
+        this.doAfterDraw(world, step);
+    }
+
+    /** Set the interceptor to run before drawing the point.  The interceptor will be provided
+     * with references to the {@link ServerWorld}, the animation step number, and the ParticlePoint
+     * instance.
+     *
+     * @param beforeDraw the new interceptor to execute before drawing the point
+     */
+    public void setBeforeDraw(DrawInterceptor<ParticlePoint, BeforeDrawData> beforeDraw) {
+        this.beforeDraw = beforeDraw;
+    }
+
+    private void doBeforeDraw(ServerWorld world, int step) {
+        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, null, step, BeforeDrawData.class);
+        this.beforeDraw.apply(interceptData, this);
+    }
+
+    /** Sets the interceptor to run after drawing the point.  The interceptor will be provided
+     * with references to the {@link ServerWorld}, the animation step number, and the ParticlePoint
+     * instance.
+     *
+     * @param afterDraw the new interceptor to execute after drawing the point
+     */
+    public void setAfterDraw(DrawInterceptor<ParticlePoint, AfterDrawData> afterDraw) {
+        this.afterDraw = afterDraw;
+    }
+
+    private void doAfterDraw(ServerWorld world, int step) {
+        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, null, step, AfterDrawData.class);
+        this.afterDraw.apply(interceptData, this);
+    }
+}

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
@@ -135,7 +135,6 @@ public class ParticleSphere extends ParticleObject {
             ParticleSphere objectInUseAfter = modifiedResultAfter.object;
             this.drawParticle(world, drawPos);
         }
-        this.endDraw(world, step, pos);
     }
 
     private Vector3f computeCoords(int i) {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
@@ -13,7 +13,7 @@ import org.joml.Vector3f;
  * can be set individually or by supplying a list of 4 vertices
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleTetrahedron extends ParticleObject{
+public class ParticleTetrahedron extends ParticleObject {
     public DrawInterceptor<ParticleTetrahedron, emptyData> afterCalcsIntercept;
     public DrawInterceptor<ParticleTetrahedron, emptyData> beforeCalcsIntercept;
 
@@ -232,7 +232,6 @@ public class ParticleTetrahedron extends ParticleObject{
         commonUtils.drawLine(this, world, vertex1, vertex3, this.amount);
         commonUtils.drawLine(this, world, vertex2, vertex3, this.amount);
         this.interceptDrawCalcAfter(world, step, drawPos, this);
-        this.endDraw(world, step, drawPos);
     }
 
     private InterceptedResult<ParticleTetrahedron, emptyData> interceptDrawCalcAfter(

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
@@ -13,7 +13,7 @@ import org.joml.Vector3f;
  * The vertices can be set individually or by supplying a list of 4 vertices
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleTriangle extends ParticleObject{
+public class ParticleTriangle extends ParticleObject {
     public DrawInterceptor<ParticleTriangle, emptyData> afterCalcsIntercept;
     public DrawInterceptor<ParticleTriangle, emptyData> beforeCalcsIntercept;
 
@@ -200,7 +200,6 @@ public class ParticleTriangle extends ParticleObject{
         commonUtils.drawLine(objectToUse, world, vertex2, vertex3, objectToUse.amount);
         commonUtils.drawLine(objectToUse, world, vertex3, vertex1, objectToUse.amount);
         this.interceptDrawCalcAfter(world, step, drawPos, this);
-        this.endDraw(world, step, drawPos);
     }
 
     private InterceptedResult<ParticleTriangle, emptyData> interceptDrawCalcAfter(


### PR DESCRIPTION
`ParticleObject` contained `setBeforeDraw` and `setAfterDraw` methods because it was serving two purposes: an abstract base and a particle point. By making it abstract, it no longer has to serve as a particle point class. Therefore, extract a proper `ParticlePoint` class, which also does a decent job at demonstrating the intended structure for a `ParticleObject` subclass.

Recognize that `endDraw` isn't used, and remove it for now.  There may be a future where `beginDraw`, `endDraw`, and `draw` are all provided, but for now, the subclasses are handling this via their `beforeDraw` and `afterDraw` `DrawInterceptor`s.