### PR TITLE
Move Sphere rendering into ApelRenderer

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
@@ -196,6 +196,21 @@ public abstract class ParticleObject {
     }
 
     /**
+     * Draws a sphere of the given particle effect at {@code drawPos} with the given {@code radius}, {@code rotation}, and {@code amount} of particles.
+     *
+     * @param renderer The renderer to use
+     * @param step The current animation step
+     * @param drawPos The position of the center of the sphere
+     * @param radius The radius of the sphere
+     * @param rotation The rotation of the sphere; this is not terribly useful, but it can be used for
+     *         interesting effect, if the number of particles in the sphere changes over time.
+     * @param amount The number of particles in the sphere
+     */
+    protected void drawSphere(ApelRenderer renderer, int step, Vector3f drawPos, float radius, Vector3f rotation, int amount) {
+        renderer.drawSphere(this.particleEffect, step, drawPos, radius, rotation, amount);
+    }
+
+    /**
      * Draws a point along an ellipse shape that has a center {@code center}.
      *
      * @param renderer The renderer to use

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
@@ -8,7 +8,6 @@ import net.minecraft.server.world.ServerWorld;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,7 +47,6 @@ public class ParticleSphere extends ParticleObject {
         super(particleEffect, rotation);
         this.setRadius(radius);
         this.setAmount(amount);
-        this.distributePoints();
     }
 
     /** Constructor for the particle cuboid which is a 3D shape. It accepts as parameters
@@ -103,40 +101,12 @@ public class ParticleSphere extends ParticleObject {
     }
 
     @Override
-    public int setAmount(int amount) {
-        int prevAmount = super.setAmount(amount);
-        if (prevAmount != amount) {
-            this.distributePoints();
-        }
-        return prevAmount;
-    }
-
-    @Override
     public void draw(ApelRenderer renderer, int step, Vector3f drawPos) {
         this.doBeforeDraw(renderer.getWorld(), step, drawPos);
-        for (int i = 0; i < this.amount; i++) {
-            Vector3f surfacePos = new Vector3f(this.cachedCoordinates.get(i));
-            surfacePos.rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x).add(drawPos).add(this.offset);
-            this.drawParticle(renderer, step, surfacePos);
-        }
+        Vector3f objectDrawPos = new Vector3f(drawPos).add(this.offset);
+        this.drawSphere(renderer, step, objectDrawPos, this.radius, this.rotation, this.amount);
         this.doAfterDraw(renderer.getWorld(), step, drawPos);
         this.endDraw(renderer, step, drawPos);
-    }
-
-    // Uses the "golden spiral" algorithm described here: https://stackoverflow.com/a/44164075
-    private void distributePoints() {
-        this.cachedCoordinates = new ArrayList<>(this.amount);
-        for (int i = 0; i < this.amount; i++) {
-            float k = i + .5f;
-            double phi = Math.acos(1f - ((2f * k) / this.amount));
-            double theta = Math.PI * k * SQRT_5_PLUS_1;
-            double sinPhi = Math.sin(phi);
-            float x = (float) (Math.cos(theta) * sinPhi);
-            float y = (float) (Math.sin(theta) * sinPhi);
-            float z = (float) Math.cos(phi);
-            Vector3f pos = new Vector3f(x, y, z).mul(this.radius);
-            this.cachedCoordinates.add(pos);
-        }
     }
 
     /** Set the interceptor to run after drawing the sphere.  The interceptor will be provided


### PR DESCRIPTION
This mimics #14 by moving the sphere drawing into `ParticleObject` and `ApelRenderer`.  Note that the default implementation here is both less and more efficient than the existing algorithm.  It is less efficient because it doesn't cache the computed points; however, the previous point cache was ineffective because it only retained a single point.  It also doesn't cache the rotations, but it makes up for that by computing the combined rotation once per tick via quaternion, which should be faster than Euler angles.

I expect that implementations of `ApelRenderer` will further optimize for point caches, rotation/quaternion caches, and more.