### PR TITLE
New instructions for Ellipse/Ellipsoid

### DIFF
--- a/src/main/java/net/mcbrincie/apel/client/ApelClient.java
+++ b/src/main/java/net/mcbrincie/apel/client/ApelClient.java
@@ -55,6 +55,28 @@ public class ApelClient implements ClientModInitializer {
                                 drawParticle(particleManager, particleEffect, pos);
                             }
                         }
+                        case ApelNetworkRenderer.Ellipsoid(
+                                Vector3f drawPos, float radius, float stretch1, float stretch2, Vector3f rotation,
+                                int amount
+                        ) -> {
+                            final double sqrt5Plus1 = 3.23606;
+                            Vector3f scale = new Vector3f(radius, stretch1, stretch2);
+                            Quaternionfc quaternion = new Quaternionf().rotateZ(rotation.z).rotateY(rotation.y).rotateX(rotation.x);
+                            for (int i = 0; i < amount; i++) {
+                                // Offset into the real-number distribution
+                                float k = i + .5f;
+                                // Project point on unit sphere
+                                double phi = Math.acos(1f - ((2f * k) / amount));
+                                double theta = Math.PI * k * sqrt5Plus1;
+                                double sinPhi = Math.sin(phi);
+                                float x = (float) (Math.cos(theta) * sinPhi);
+                                float y = (float) (Math.sin(theta) * sinPhi);
+                                float z = (float) Math.cos(phi);
+                                // Scale, rotate, translate
+                                Vector3f pos = new Vector3f(x, y, z).mul(scale).rotate(quaternion).add(drawPos);
+                                drawParticle(particleManager, particleEffect, pos);
+                            }
+                        }
                     }
                 }
             });

--- a/src/main/java/net/mcbrincie/apel/lib/renderers/ApelFramePayload.java
+++ b/src/main/java/net/mcbrincie/apel/lib/renderers/ApelFramePayload.java
@@ -30,6 +30,7 @@ public record ApelFramePayload(List<ApelNetworkRenderer.Instruction> instruction
                 case 'L' -> instructions.add(ApelNetworkRenderer.Line.from(buf));
                 case 'P' -> instructions.add(ApelNetworkRenderer.Particle.from(buf));
                 case 'E' -> instructions.add(ApelNetworkRenderer.Ellipse.from(buf));
+                case 'S' -> instructions.add(ApelNetworkRenderer.Ellipsoid.from(buf));
             }
         }
         return instructions;

--- a/src/main/java/net/mcbrincie/apel/lib/renderers/ApelNetworkRenderer.java
+++ b/src/main/java/net/mcbrincie/apel/lib/renderers/ApelNetworkRenderer.java
@@ -38,6 +38,17 @@ public class ApelNetworkRenderer implements ApelRenderer {
     }
 
     @Override
+    public void drawSphere(ParticleEffect particleEffect,
+                           int step,
+                           Vector3f drawPos,
+                           float radius,
+                           Vector3f rotation,
+                           int amount) {
+        this.detectParticleTypeChange(particleEffect);
+        this.instructions.add(new Ellipsoid(drawPos, radius, radius, radius, rotation, amount));
+    }
+
+    @Override
     public void drawEllipse(ParticleEffect particleEffect,
                             int step,
                             Vector3f center,
@@ -166,6 +177,34 @@ public class ApelNetworkRenderer implements ApelRenderer {
             buf.writeFloat(center.z);
             buf.writeFloat(radius);
             buf.writeFloat(stretch);
+            buf.writeFloat(rotation.x);
+            buf.writeFloat(rotation.y);
+            buf.writeFloat(rotation.z);
+            buf.writeShort(amount);
+        }
+    }
+
+    public record Ellipsoid(Vector3f drawPos, float radius, float stretch1, float stretch2, Vector3f rotation,
+                            int amount) implements Instruction {
+
+        static Ellipsoid from(RegistryByteBuf buf) {
+            return new Ellipsoid(new Vector3f(buf.readFloat(), buf.readFloat(), buf.readFloat()),
+                                 buf.readFloat(),
+                                 buf.readFloat(),
+                                 buf.readFloat(),
+                                 new Vector3f(buf.readFloat(), buf.readFloat(), buf.readFloat()),
+                                 buf.readShort());
+        }
+
+        @Override
+        public void write(RegistryByteBuf buf) {
+            buf.writeByte('S');
+            buf.writeFloat(drawPos.x);
+            buf.writeFloat(drawPos.y);
+            buf.writeFloat(drawPos.z);
+            buf.writeFloat(radius);
+            buf.writeFloat(stretch1);
+            buf.writeFloat(stretch2);
             buf.writeFloat(rotation.x);
             buf.writeFloat(rotation.y);
             buf.writeFloat(rotation.z);


### PR DESCRIPTION
Adds `Instruction` implementations for ellipse (also does circle) and ellipsoid (only does sphere so far, but is ready for an ellipsoid).