### PR TITLE
Documentation pass (mostly) on particle objects

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
@@ -33,6 +33,10 @@ public class ParticleCircle extends ParticleObject {
      * the particle effect to use, the radius of the circle, the rotation to apply, and the number of particles.
      * There is also a simplified version for no rotation.
      *
+     * <p>This implementation calls setters for amount, rotation, and radius so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
+     *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
      * @param radius The radius of the circle (how big it is)
@@ -49,6 +53,10 @@ public class ParticleCircle extends ParticleObject {
     /** Constructor for the particle circle which is a 2D shape. It accepts as parameters
      * the particle effect to use, the radius of the circle, & the number of particles.
      * There is also a version that allows for rotation.
+     *
+     * <p>This implementation calls setters for amount, rotation, and radius so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCone.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCone.java
@@ -26,8 +26,12 @@ public class ParticleCone extends ParticleObject {
 
     /** Constructor for the particle cone which is a 3D shape. It accepts as parameters
      * the particle effect to use, the height of the cone, the maximum radius,
-     * the rotation to apply and the number of particles.
-     * There is also a simplified constructor for no rotation
+     * the rotation to apply, and the number of particles.
+     * There is also a simplified constructor for no rotation.
+     *
+     * <p>This implementation calls setters for rotation, amount, height, and radius so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle effect to use
      * @param height The height of the cone
@@ -38,9 +42,8 @@ public class ParticleCone extends ParticleObject {
      * @see ParticleCone#ParticleCone(ParticleEffect, float, float, int)
     */
     public ParticleCone(ParticleEffect particleEffect, float height, float radius, Vector3f rotation, int amount) {
-        super(particleEffect);
+        super(particleEffect, rotation);
         this.setAmount(amount);
-        this.setRotation(rotation);
         this.setHeight(height);
         this.setRadius(radius);
     }
@@ -49,6 +52,10 @@ public class ParticleCone extends ParticleObject {
      * the particle effect to use, the height of the cone, the maximum radius,
      * the rotation to apply and the number of particles.
      * There is also a more complex version for rotation
+     *
+     * <p>This implementation calls setters for rotation, amount, height, and radius so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle effect to use
      * @param height The height of the cone
@@ -74,6 +81,14 @@ public class ParticleCone extends ParticleObject {
         this.afterDraw = cone.afterDraw;
     }
 
+    /** Gets the height of the cone
+     *
+     * @return The height of the cone
+     */
+    public float getHeight() {
+        return this.height;
+    }
+
     /** Sets the height of the cone
      *
      * @param height The new height
@@ -87,12 +102,6 @@ public class ParticleCone extends ParticleObject {
         this.height = height;
         return prevHeight;
     }
-
-    /** Gets the height of the cone
-     *
-     * @return The height of the cone
-     */
-    public float getHeight() {return this.height;}
 
     /** Gets the maximum radius of the cone and returns it.
      *

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCylinder.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCylinder.java
@@ -10,14 +10,19 @@ import org.joml.Vector3f;
 
 import java.util.Optional;
 
-/** The particle object class that represents a 3D cylinder.
+/** The particle object class that represents a cylinder.
  * It has a radius which dictates how large or small the cylinder is depending on the
- * radius value supplied and a height value for how tall it is
+ * radius value supplied and a height value for how tall it is.  The cylinder is drawn
+ * with particles evenly dispersed around its sides, but has no particles filling in
+ * the bases.  One base is in the xz-plane by default, and the other base is in the positive-y
+ * direction.  If the cylinder should be in the negative-y direction, a rotation about the
+ * x-axis will achieve that.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleCylinder extends ParticleObject {
     protected float radius;
     protected float height;
+
     private DrawInterceptor<ParticleCylinder, AfterDrawData> afterDraw = DrawInterceptor.identity();
     private DrawInterceptor<ParticleCylinder, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
 
@@ -27,10 +32,12 @@ public class ParticleCylinder extends ParticleObject {
     /** This data is used after calculations (it contains the drawing position) */
     public enum AfterDrawData {}
 
-    /** Constructor for the particle cylinder which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the radius of the cylinder, the height of the cylinder,
-     * the rotation to apply & the number of particles. There is also a simplified version
-     * for no rotation.
+    /** Constructor for the particle cylinder. It accepts as parameters the particle effect to use, the radius of the
+     * cylinder, the height of the cylinder, the rotation to apply, and the number of particles.
+     *
+     * <p>This implementation calls setters for amount, rotation, height, and radius so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
@@ -41,8 +48,7 @@ public class ParticleCylinder extends ParticleObject {
      * @see ParticleCylinder#ParticleCylinder(ParticleEffect, float, float, int)
     */
     public ParticleCylinder(
-            @NotNull ParticleEffect particleEffect, float radius,
-            float height, Vector3f rotation, int amount
+            @NotNull ParticleEffect particleEffect, float radius, float height, Vector3f rotation, int amount
     ) {
         super(particleEffect, rotation);
         this.setRadius(radius);
@@ -50,9 +56,12 @@ public class ParticleCylinder extends ParticleObject {
         this.setHeight(height);
     }
 
-    /** Constructor for the particle cylinder which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the radius of the cylinder, the height of the cylinder
-     * & the number of particles. There is also a version that allows for rotation.
+    /** Constructor for the particle cylinder. It accepts as parameters the particle effect to use, the radius of the
+     * cylinder, the height of the cylinder, and the number of particles.
+     *
+     * <p>This implementation calls setters for amount, rotation, height, and radius so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
@@ -76,10 +85,10 @@ public class ParticleCylinder extends ParticleObject {
     public ParticleCylinder(ParticleCylinder cylinder) {
         super(cylinder);
         this.radius = cylinder.radius;
+        this.height = cylinder.height;
         this.amount = cylinder.amount;
         this.afterDraw = cylinder.afterDraw;
         this.beforeDraw = cylinder.beforeDraw;
-        this.height = cylinder.height;
     }
 
     /** Gets the radius of the ParticleCylinder and returns it.
@@ -90,34 +99,36 @@ public class ParticleCylinder extends ParticleObject {
         return radius;
     }
 
-    /** Set the radius of this ParticleCylinder and returns the previous radius that was used.
+    /** Set the radius of this ParticleCylinder and returns the previous radius that was used.  Radius must be positive.
      *
      * @param radius the new radius
      * @return the previously used radius
      */
     public float setRadius(float radius) {
         if (radius < 0) {
-            throw new IllegalArgumentException("Height cannot be negative");
+            throw new IllegalArgumentException("Radius must be positive");
         }
         float prevRadius = this.radius;
         this.radius = radius;
         return prevRadius;
     }
 
-    /** Gets the height of the ParticleCylinder and returns it
+    /** Gets the height of the ParticleCylinder and returns it.
      *
      * @return the height of the ParticleCylinder
     */
-    public float getHeight() {return height;}
+    public float getHeight() {
+        return height;
+    }
 
-    /** Sets the height of the ParticleCylinder and returns the previous height that was used
+    /** Sets the height of the ParticleCylinder and returns the previous height that was used.  Height must be positive.
      *
      * @param height The new height
      * @return The previous used height
      */
     public float setHeight(float height) {
         if (height < 0) {
-            throw new IllegalArgumentException("Height cannot be negative");
+            throw new IllegalArgumentException("Height must be positive");
         }
         float prevHeight = this.height;
         this.height = height;
@@ -135,8 +146,7 @@ public class ParticleCylinder extends ParticleObject {
 
     /** Set the interceptor to run after drawing the cylinder. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position where the cylinder is rendered.  It will also have the position around the cylinder
-     * at which the current particle was drawn.
+     * position where the cylinder is rendered.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
@@ -151,8 +161,7 @@ public class ParticleCylinder extends ParticleObject {
 
     /** Set the interceptor to run prior to drawing the cylinder. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position where the cylinder is rendered.  It will also have the angle around the cylinder at
-     * which the current particle is.
+     * position where the cylinder is rendered.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing each particle
      */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipse.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipse.java
@@ -10,65 +10,69 @@ import org.joml.Vector3f;
 
 import java.util.Optional;
 
-/** The particle object class that represents a 2D ellipse.
+/** The particle object class that represents an ellipse.
  * It has a radius which dictates how large or small the ellipse is depending on the
- * radius value supplied and a stretch value for how stretched is the ellipse. A value of
- * stretch that equals the radius means it is a circle
+ * radius value supplied and a stretch value for how stretched is the ellipse.  The radius
+ * value is used as the X semi-axis, and the stretch value is used as the Y semi-axis.
+ * Setting radius and stretch equal to one another means it is a circle.  The ellipse is
+ * drawn in the xy-plane by default, though rotations can move it around.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleEllipse extends ParticleObject {
     protected float radius;
     protected float stretch;
+
     private DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw = DrawInterceptor.identity();
     private DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
 
-    /** This data is used before calculations (it contains the iterated rotation) */
-    public enum BeforeDrawData {
-        ITERATED_ROTATION
-    }
+    /** This data is used before calculations */
+    public enum BeforeDrawData {}
 
-    /** This data is used after calculations (it contains the drawing position) */
-    public enum AfterDrawData {
-        DRAW_POSITION
-    }
+    /** This data is used after calculations */
+    public enum AfterDrawData {}
 
     /** Constructor for the particle ellipse which is a 3D shape. It accepts as parameters
      * the particle effect to use, the radius of the ellipse, the stretch of the ellipse,
-     * the rotation to apply & the number of particles. There is also a simplified version
-     * for no rotation.
+     * the rotation to apply, and the number of particles.
+     *
+     * <p>This implementation calls setters for rotation, radius, stretch, and so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
-     * @param radius The radius of the ellipse (how big it is)
-     * @param stretch The stretch of the ellipse (how stretched it is)
+     * @param radius The radius of the ellipse
+     * @param stretch The stretch of the ellipse
      * @param rotation The rotation to apply
      *
      * @see ParticleEllipse#ParticleEllipse(ParticleEffect, float, float, int)
      */
     public ParticleEllipse(
-            @NotNull ParticleEffect particleEffect, float radius,
-            float stretch, Vector3f rotation, int amount
+            @NotNull ParticleEffect particleEffect, float radius, float stretch, Vector3f rotation, int amount
     ) {
         super(particleEffect, rotation);
         this.setRadius(radius);
-        this.setAmount(amount);
         this.setStretch(stretch);
+        this.setAmount(amount);
     }
 
     /** Constructor for the particle ellipse which is a 3D shape. It accepts as parameters
      * the particle effect to use, the radius of the ellipse, the stretch of the ellipse
      * & the number of particles. There is also a version that allows for rotation.
      *
+     * <p>This implementation calls setters for rotation, radius, stretch, and so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
+     *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
-     * @param stretch The stretch of the ellipse (how stretched it is)
-     * @param radius The radius of the ellipse (how big it is)
+     * @param radius The radius of the ellipse
+     * @param stretch The stretch of the ellipse
      *
      * @see ParticleEllipse#ParticleEllipse(ParticleEffect, float, float, Vector3f, int)
      */
     public ParticleEllipse(
-            @NotNull ParticleEffect particleEffect,
-            float radius, float stretch, int amount
+            @NotNull ParticleEffect particleEffect, float radius, float stretch, int amount
     ) {
         this(particleEffect, radius, stretch, new Vector3f(0,0,0), amount);
     }
@@ -81,10 +85,10 @@ public class ParticleEllipse extends ParticleObject {
     public ParticleEllipse(ParticleEllipse ellipse) {
         super(ellipse);
         this.radius = ellipse.radius;
-        this.amount = ellipse.amount;
-        this.afterDraw = ellipse.afterDraw;
-        this.beforeDraw = ellipse.beforeDraw;
         this.stretch = ellipse.stretch;
+        this.amount = ellipse.amount;
+        this.beforeDraw = ellipse.beforeDraw;
+        this.afterDraw = ellipse.afterDraw;
     }
 
     /** Gets the radius of the ParticleEllipse and returns it.
@@ -109,13 +113,15 @@ public class ParticleEllipse extends ParticleObject {
         return prevRadius;
     }
 
-    /** Gets the stretch of the ParticleEllipse and returns it
+    /** Gets the stretch of the ParticleEllipse and returns it.
      *
      * @return the stretch of the ParticleEllipse
      */
-    public float getStretch() {return stretch;}
+    public float getStretch() {
+        return stretch;
+    }
 
-    /** Sets the stretch of the ParticleEllipse and returns the previous stretch that was used
+    /** Sets the stretch of the ParticleEllipse and returns the previous stretch that was used.
      *
      * @param stretch The new stretch
      * @return The previous used stretch
@@ -141,7 +147,7 @@ public class ParticleEllipse extends ParticleObject {
 
     /** Set the interceptor to run after drawing the ellipse. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position where the ellipse is rendered.
+     * position of the center of the ellipse.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
@@ -156,7 +162,7 @@ public class ParticleEllipse extends ParticleObject {
 
     /** Set the interceptor to run prior to drawing the ellipse. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position where the ellipse is rendered.
+     * position of the center of the ellipse.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing each particle
      */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipsoid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipsoid.java
@@ -38,7 +38,11 @@ public class ParticleEllipsoid extends ParticleObject {
     /**
      * Constructor for the particle ellipsoid which is a 3D shape. It accepts as parameters
      * the particle effect to use, the semi-axes of the ellipsoid, the number of particles,
-     * and the rotation to apply. There is also a simplified version for no rotation.
+     * and the rotation to apply.
+     *
+     * <p>This implementation calls setters for rotation, semi-axes, and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param xSemiAxis The length of the X semi-axis
@@ -46,6 +50,7 @@ public class ParticleEllipsoid extends ParticleObject {
      * @param zSemiAxis The length of the Z semi-axis
      * @param amount The number of particles for the object
      * @param rotation The rotation to apply
+     *
      * @see ParticleEllipsoid#ParticleEllipsoid(ParticleEffect, float, float, float, int)
      */
     public ParticleEllipsoid(
@@ -62,13 +67,17 @@ public class ParticleEllipsoid extends ParticleObject {
     /**
      * Constructor for the particle cuboid which is a 3D shape. It accepts as parameters
      * the particle effect to use, the semi-axes of the ellipsoid, and the number of particles.
-     * It is a simplified version for the case when no rotation is meant to be applied.
+     *
+     * <p>This implementation calls setters for rotation, semi-axes, and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param xSemiAxis The length of the X semi-axis
      * @param ySemiAxis The length of the Y semi-axis
      * @param zSemiAxis The length of the Z semi-axis
      * @param amount The number of particles for the object
+     *
      * @see ParticleEllipsoid#ParticleEllipsoid(ParticleEffect, float, float, float, int, Vector3f)
      */
     public ParticleEllipsoid(
@@ -79,7 +88,7 @@ public class ParticleEllipsoid extends ParticleObject {
 
     /**
      * The copy constructor for a specific particle object. It copies all
-     * the params, including the interceptors the particle object has
+     * the params, including the interceptors the particle object has.
      *
      * @param particleEllipsoid The particle ellipsoid object to copy from
      */
@@ -89,12 +98,12 @@ public class ParticleEllipsoid extends ParticleObject {
         this.ySemiAxis = particleEllipsoid.ySemiAxis;
         this.zSemiAxis = particleEllipsoid.zSemiAxis;
         this.amount = particleEllipsoid.amount;
-        this.afterDraw = particleEllipsoid.afterDraw;
         this.beforeDraw = particleEllipsoid.beforeDraw;
+        this.afterDraw = particleEllipsoid.afterDraw;
     }
 
     /**
-     * Gets length of the X semi-axis
+     * Gets length of the X semi-axis.
      *
      * @return the length of the X semi-axis
      */
@@ -103,7 +112,7 @@ public class ParticleEllipsoid extends ParticleObject {
     }
 
     /**
-     * Sets length of the X semi-axis
+     * Sets length of the X semi-axis.
      *
      * @param xSemiAxis The length of the X semi-axis
      * @return The previous length of the X semi-axis
@@ -118,7 +127,7 @@ public class ParticleEllipsoid extends ParticleObject {
     }
 
     /**
-     * Gets length of the Y semi-axis
+     * Gets length of the Y semi-axis.
      *
      * @return the length of the Y semi-axis
      */
@@ -127,7 +136,7 @@ public class ParticleEllipsoid extends ParticleObject {
     }
 
     /**
-     * Sets length of the Y semi-axis
+     * Sets length of the Y semi-axis.
      *
      * @param ySemiAxis The length of the Y semi-axis
      * @return The previous length of the Y semi-axis
@@ -142,7 +151,7 @@ public class ParticleEllipsoid extends ParticleObject {
     }
 
     /**
-     * Gets length of the Z semi-axis
+     * Gets length of the Z semi-axis.
      *
      * @return the length of the Z semi-axis
      */
@@ -151,7 +160,7 @@ public class ParticleEllipsoid extends ParticleObject {
     }
 
     /**
-     * Sets length of the Z semi-axis
+     * Sets length of the Z semi-axis.
      *
      * @param zSemiAxis The length of the Z semi-axis
      * @return The previous length of the Z semi-axis
@@ -178,8 +187,8 @@ public class ParticleEllipsoid extends ParticleObject {
 
     /**
      * Set the interceptor to run after drawing the ellipsoid.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the position
-     * where the ellipsoid is rendered.
+     * with references to the {@link ServerWorld}, the step number of the animation, and the center
+     * of the ellipsoid.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
@@ -194,8 +203,8 @@ public class ParticleEllipsoid extends ParticleObject {
 
     /**
      * Set the interceptor to run prior to drawing the ellipsoid.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the position
-     * where the ellipsoid is rendered.
+     * with references to the {@link ServerWorld}, the step number of the animation, and the center
+     * of the ellipsoid.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing the ellipsoid
      */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 /** The particle object class that represents a 2D line. It is one of the
  * most simple objects to use as it needs only a start & an ending position
  * to draw that line. The line cannot be curved and is only linear.
- * <br><br>
- * <b>Note:</b> rotation won't be applied to the calculations, as such it doesn't make
+ *
+ * <p><b>Note:</b> Rotation is not applied to the calculations, as such it doesn't make
  * any difference.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
@@ -31,6 +31,10 @@ public class ParticleLine extends ParticleObject {
      * the particle effect to use, the starting endpoint & the ending endpoint. Rotation
      * doesn't matter in this context.
      *
+     * <p>This implementation calls a setter for amount so checks are performed to
+     * ensure valid values are accepted.  Subclasses should take care not to violate this lest
+     * they risk undefined behavior.
+     *
      * @param particleEffect The particle effect to use
      * @param start The starting endpoint
      * @param end The ending endpoint
@@ -47,19 +51,28 @@ public class ParticleLine extends ParticleObject {
     }
 
     /** The copy constructor for a specific particle object. It copies all
-     * the params, including the interceptors the particle object has
+     * the params, including the interceptors the particle object has.  The start and end points are copied to new
+     * vectors.
      *
      * @param line The particle object to copy from
     */
     public ParticleLine(ParticleLine line) {
         super(line);
-        this.end = line.end;
-        this.start = line.start;
+        this.start = new Vector3f(line.start);
+        this.end = new Vector3f(line.end);
         this.beforeDraw = line.beforeDraw;
         this.afterDraw = line.afterDraw;
     }
 
-    /** Sets the starting point of the line
+    /** Gets the starting endpoint
+     *
+     * @return The starting endpoint
+     */
+    public Vector3f getStart() {
+        return this.start;
+    }
+
+    /** Sets the starting point of the line.
      *
      * @param start The new starting point of the line
      * @return The previous starting point
@@ -73,7 +86,15 @@ public class ParticleLine extends ParticleObject {
         return prevStart;
     }
 
-    /** Sets the ending point of the line
+    /** Gets the ending endpoint
+     *
+     * @return The ending endpoint
+     */
+    public Vector3f getEnd() {
+        return this.end;
+    }
+
+    /** Sets the ending point of the line.
      *
      * @param end The new ending point of the line
      * @return The previous ending point
@@ -90,29 +111,15 @@ public class ParticleLine extends ParticleObject {
     @Override
     @Deprecated
     public Vector3f getRotation() {
+        // Do not throw UnsupportedOperationException in case this is called in a series of ParticleObjects
         return null;
     }
 
     @Override
     @Deprecated
     public Vector3f setRotation(Vector3f rotation) {
+        // Do not throw UnsupportedOperationException in case this is called in a series of ParticleObjects
         return null;
-    }
-
-    /** Gets the starting endpoint
-     *
-     * @return The starting endpoint
-     */
-    public Vector3f getStart() {
-        return this.start;
-    }
-
-    /** Gets the ending endpoint
-     *
-     * @return The ending endpoint
-     */
-    public Vector3f getEnd() {
-        return this.end;
     }
 
     @Override

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePoint.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePoint.java
@@ -10,16 +10,12 @@ import org.joml.Vector3f;
 import java.util.Optional;
 
 
-/** The base class for any particle object. Particle objects are the things
- * that will be rendered. This can be a cube, a sphere, a 2D circle, a cat, a
- * dog... etc. The calculation logic is done in the draw method which the
- * handler system periodically calls each render step. You can inherit
- * from the class and even use it (it will be a point), it has common interceptors
- * like the before calculation interceptor & the after calculation interceptor.
- * <br><br>
- * <strong>Note</strong> rotation calculations are in radians and not in degrees.
- * As well as if the rotation on one or multiple axis exceeds 2π, then it is rounded
- * to the scope for that (-2π, 2π)
+/**
+ * ParticlePoint allows for single particles to be rendered.  It will generally be used in conjunction
+ * with other ParticleObjects, likely as part of a ParticleCombiner.  As a single point, scaling and rotation
+ * do not apply, since Minecraft will render all particles facing the camera.  By default, it will be drawn
+ * at the {@code drawPos} in the {@link #draw(ApelServerRenderer, int, Vector3f)} method.  Translation is possible
+ * using {@link #setOffset(Vector3f)}.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticlePoint extends ParticleObject {
@@ -31,27 +27,10 @@ public class ParticlePoint extends ParticleObject {
     }
     public enum AfterDrawData {}
 
-
-    /** Constructor for the particle object which is a point. It accepts as parameters
-     * the particle to use and the rotation to apply (which has no effect. Only on the
-     * path animators that extend this class). There is also a simplified version
-     * for no rotation.
-     *
-     * @see ParticlePoint#ParticlePoint(ParticlePoint)
-     *
-     * @param particleEffect The particle effect to use
-     * @param rotation The rotation (IN RADIANS)
-    */
-    public ParticlePoint(ParticleEffect particleEffect, Vector3f rotation) {
-        super(particleEffect, rotation);
-    }
-
     /** Constructor for the particle object which is a point. It accepts as parameters
      * the particle effect to use. It is a simplified version of the previous constructor
      * and is meant to be used when you want the object to not have a rotation offset.
      * In the case you do want, there is a constructor for that (won't apply to this class)
-     *
-     * @see ParticlePoint#ParticlePoint(ParticleEffect, Vector3f)
      *
      * @param particleEffect The particle effect to use
     */
@@ -60,7 +39,7 @@ public class ParticlePoint extends ParticleObject {
     }
 
     /** The copy constructor for a specific particle object. It copies all
-     * the params, including the interceptors the particle object has
+     * the params, including the interceptors the particle object has.
      *
      * @param object The particle object to copy from
      */
@@ -78,9 +57,9 @@ public class ParticlePoint extends ParticleObject {
         this.endDraw(renderer, step, objectDrawPosition);
     }
 
-
-    /** Sets the before draw interceptor, the method executes right before the particle point
-     * is drawn onto the screen. And for data it has the drawing position
+    /** Set the interceptor to run before drawing the cone. The interceptor will be provided
+     * with references to the {@link ServerWorld}, the animation step number, and the ParticlePoint
+     * instance.  The metadata will include the drawing position.
      *
      * @param beforeDraw The new interceptor to use
      */
@@ -88,8 +67,9 @@ public class ParticlePoint extends ParticleObject {
         this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
     }
 
-    /** Sets the after draw interceptor, the method executes right after the particle point
-     * is drawn onto the screen. And has no data attached
+    /** Set the interceptor to run before drawing the cone. The interceptor will be provided
+     * with references to the {@link ServerWorld}, the animation step number, and the ParticlePoint
+     * instance.
      *
      * @param afterDraw The new interceptor to use
     */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePolygon.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePolygon.java
@@ -6,8 +6,6 @@ import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -18,13 +16,11 @@ import java.util.Optional;
 
 /** The particle object class that represents a 2D regular polygon. Regular polygons contain the
  * same angles as well as the same edges; Examples include but are not limited to a square, a pentagon,
- * an isosceles triangle... etc. The polygon takes a variable "sides" that dictates which shape to use and
- * calculates the vertices of that shape and connects them
+ * an equilateral triangle, etc. The polygon takes a variable "sides" that dictates how many sides the polygon
+ * will have.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticlePolygon extends ParticleObject {
-    private static final Logger LOGGER = LogManager.getLogger();
-
     protected int sides;
     protected float size;
 
@@ -36,10 +32,15 @@ public class ParticlePolygon extends ParticleObject {
     /** There is no data being transmitted */
     public enum CommonData {}
 
-    /** Constructor for the particle polygon which is a 2D regular polygon(shape).
+    /** Constructor for the particle polygon which is a 2D regular polygon.
      * It accepts as parameters the particle effect to use, the sides of the polygon,
      * the size of the polygon, the number of particles, and the rotation to apply.
-     * There is also a simplified version for no rotation.
+     *
+     * <p>The size of the polygon is the distance from the center of the polygon to any of its vertices.
+     *
+     * <p>This implementation calls setters for rotation, sides, size, and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param sides The of the regular polygon
@@ -56,10 +57,15 @@ public class ParticlePolygon extends ParticleObject {
         this.setAmount(amount);
     }
 
-    /** Constructor for the particle polygon which is a 2D regular polygon(shape).
+    /** Constructor for the particle polygon which is a 2D regular polygon.
      * It accepts as parameters the particle effect to use, the sides of the polygon,
      * the size of the polygon, and the number of particles.
-     * There is also a more complex version for supplying rotation.
+     *
+     * <p>The size of the polygon is the distance from the center of the polygon to any of its vertices.
+     *
+     * <p>This implementation calls setters for rotation, sides, size, and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param size The size of the regular polygon
@@ -73,7 +79,7 @@ public class ParticlePolygon extends ParticleObject {
     }
 
     /** The copy constructor for a specific particle object. It copies all
-     * the params, including the interceptors the particle object has
+     * the params, including the interceptors the particle object has.
      *
      * @param polygon The particle polygon object to copy from
     */
@@ -86,7 +92,7 @@ public class ParticlePolygon extends ParticleObject {
         this.afterDraw = polygon.afterDraw;
     }
 
-    /** Sets the sides to a new value and returns the previous sides used
+    /** Sets the sides to a new value and returns the previous sides used.
      *
      * @param sides The new sides
      * @throws IllegalArgumentException If the sides are less than 3
@@ -101,7 +107,7 @@ public class ParticlePolygon extends ParticleObject {
         return prevSides;
     }
 
-    /** Gets the sides of the regular polygon
+    /** Gets the sides of the regular polygon.
      *
      * @return The sides of the regular polygon
      */
@@ -109,7 +115,7 @@ public class ParticlePolygon extends ParticleObject {
         return this.sides;
     }
 
-    /** Sets the size of the polygon to a new value and returns the previous size used
+    /** Sets the size of the polygon to a new value and returns the previous size used.
      *
      * @param size The new size
      * @throws IllegalArgumentException If the size is negative or 0
@@ -187,8 +193,8 @@ public class ParticlePolygon extends ParticleObject {
         }
     }
 
-    /** Sets the after draw interceptor, the method executes right after the particle polygon
-     * is drawn onto the screen, it has nothing attached.
+     /** Sets the interceptor to run after drawing the polygon. The interceptor will be provided with references to
+      * the {@link ServerWorld}, the animation step number, and the ParticlePolygon instance.
      *
      * @param afterDraw The new interceptor to use
      */
@@ -201,8 +207,8 @@ public class ParticlePolygon extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Sets the before draw interceptor, the method executes right before the particle polygon
-     * is drawn onto the screen, it has nothing attached.
+    /** Sets the interceptor to run before drawing the polygon. The interceptor will be provided with references to
+     * the {@link ServerWorld}, the animation step number, and the ParticlePolygon instance.
      *
      * @param beforeDraw The new interceptor to use
      */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleQuad.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleQuad.java
@@ -14,11 +14,10 @@ import org.joml.Vector3f;
 import java.util.Optional;
 
 
-/** The particle object class that represents a 2D quad. It is a little
- * more complex than a line, since the user has to care about four endpoints
- * (if they don't want a square, otherwise they can supply a width & height).
- * <br>
- * The quadrilateral is drawn in order of the vertices provided (presume the line
+/** The particle object class that represents a quadrilateral.  This can be a rectangle, a square, a trapezoid,
+ * or any irregular shape with four sides.  There is no restriction on the vertices being co-planar.
+ *
+ * <p>The quadrilateral is drawn in order of the vertices provided (presume the line
  * from vertex2 to vertex3 is straight, ignoring the limitations of ASCII art):
  * <pre>
  *     vertex1 ------------------ vertex2
@@ -26,8 +25,7 @@ import java.util.Optional;
  *         \                         |
  *          \                        |
  *        vertex4 --------------- vertex3
- * </pre><br>
-*  Of course, a quad can also be a rectangle, a trapezoid and anything else in between
+ * </pre>
  */
 @SuppressWarnings("unused")
 public class ParticleQuad extends ParticleObject {
@@ -138,10 +136,9 @@ public class ParticleQuad extends ParticleObject {
         this.afterDraw = quad.afterDraw;
     }
 
-    /** Sets the individual vertices all at once instead of one at a time.
+    /** Sets all vertices at once instead of one at a time.
      * If you want to set one vertex at a time, then its recommend to use
-     * the methods ``setVertex1``, ``setVertex2``... etc. The vertices have to
-     * be 4 to modify the values, it returns nothing
+     * the methods {@link #setVertex1(Vector3f)}, etc.
      *
      * @param vertices The vertices to modify
      *
@@ -159,7 +156,7 @@ public class ParticleQuad extends ParticleObject {
 
     /** Sets the first individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -174,7 +171,7 @@ public class ParticleQuad extends ParticleObject {
 
     /** Sets the second individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -189,7 +186,7 @@ public class ParticleQuad extends ParticleObject {
 
     /** Sets the third individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -204,7 +201,7 @@ public class ParticleQuad extends ParticleObject {
 
     /** Sets the fourth individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -217,7 +214,7 @@ public class ParticleQuad extends ParticleObject {
         return prevVertex;
     }
 
-    /** Gets the first individual vertex
+    /** Gets the first individual vertex.
      *
      * @return The first individual vertex
     */
@@ -225,7 +222,7 @@ public class ParticleQuad extends ParticleObject {
         return this.vertex1;
     }
 
-    /** Gets the second individual vertex
+    /** Gets the second individual vertex.
      *
      * @return The second individual vertex
     */
@@ -233,7 +230,7 @@ public class ParticleQuad extends ParticleObject {
         return this.vertex2;
     }
 
-    /** Gets the third individual vertex
+    /** Gets the third individual vertex.
      *
      * @return The third individual vertex
     */
@@ -241,7 +238,7 @@ public class ParticleQuad extends ParticleObject {
         return this.vertex3;
     }
 
-    /** Gets the fourth individual vertex
+    /** Gets the fourth individual vertex.
      *
      * @return The fourth individual vertex
     */
@@ -273,8 +270,9 @@ public class ParticleQuad extends ParticleObject {
         this.endDraw(renderer, step, drawPos);
     }
 
-    /** Sets the after draw interceptor, the method executes right after the particle quad
-     * is drawn onto the screen. It has the four modified vertices to attach.
+    /** Sets the interceptor to run after drawing the quadrilateral. The interceptor will be provided with references
+     * to the {@link ServerWorld}, the animation step number, and the ParticleQuad instance.  The metadata has the four
+     * modified vertices.
      *
      * @param afterDraw The new interceptor to use
      */
@@ -293,8 +291,8 @@ public class ParticleQuad extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Sets the before draw interceptor, the method executes right before the particle quad
-     * is drawn onto the screen. It has no data attached.
+    /** Set the interceptor to run before drawing the quadrilateral. The interceptor will be provided with references
+     * to the {@link ServerWorld}, the animation step number, and the ParticleQuad instance.
      *
      * @param beforeDraw The new interceptor to use
      */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
@@ -10,10 +10,9 @@ import org.joml.Vector3f;
 
 import java.util.Optional;
 
-/** The particle object class that represents a sphere(3D shape) and not a 2D circle.
- * It has a radius which dictates how large or small the sphere is depending on the
- * radius value supplied. And it uses the Fibonacci point distribution algorithm
- * to place the particles around the sphere (which makes it convincing)
+/** The particle object class that represents a sphere.
+ * It has a radius which dictates how large or small the sphere is.  It projects the <em>golden spiral</em>
+ * on to the sphere to distribute particles evenly across the surface.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleSphere extends ParticleObject {
@@ -23,16 +22,20 @@ public class ParticleSphere extends ParticleObject {
     private DrawInterceptor<ParticleSphere, AfterDrawData> afterDraw = DrawInterceptor.identity();
     private DrawInterceptor<ParticleSphere, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
 
-    /** This data is used before calculations (it contains the number of particles) */
+    /** This data is used before calculations */
     public enum BeforeDrawData {}
 
-    /** This data is used after calculations (it contains the drawing position & the number of particles) */
+    /** This data is used after calculations */
     public enum AfterDrawData {}
 
     /**
      * Constructor for the particle sphere which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the radius of the sphere, the number of particles.
-     * And the rotation to apply. There is also a simplified version for no rotation.
+     * the particle effect to use, the radius of the sphere, the number of particles,
+     * and the rotation to apply.
+     *
+     * <p>This implementation calls setters for rotation, radius, and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param radius   The radius of the sphere
@@ -47,9 +50,11 @@ public class ParticleSphere extends ParticleObject {
     }
 
     /** Constructor for the particle cuboid which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the radius of the sphere & the number of particles.
-     * It is a simplified version for the case when no rotation is meant to be applied.
-     * For rotation offset, you can use another constructor
+     * the particle effect to use, the radius of the sphere, the number of particles.
+     *
+     * <p>This implementation calls setters for rotation, radius, and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
@@ -62,7 +67,7 @@ public class ParticleSphere extends ParticleObject {
     }
 
     /** The copy constructor for a specific particle object. It copies all
-     * the params, including the interceptors the particle object has
+     * the params, including the interceptors the particle object has.
      *
      * @param sphere The particle sphere object to copy from
     */
@@ -74,21 +79,21 @@ public class ParticleSphere extends ParticleObject {
         this.beforeDraw = sphere.beforeDraw;
     }
 
-    /** Sets the radius of the sphere
+    /** Sets the radius of the sphere.  The radius must be positive.
      *
      * @param radius The radius of the sphere
      * @return The previous radius used
     */
     public float setRadius(float radius) {
         if (radius <= 0) {
-            throw new IllegalArgumentException("Radius cannot be below or equal to 0");
+            throw new IllegalArgumentException("Radius must be positive");
         }
         float prevRadius = this.radius;
         this.radius = radius;
         return prevRadius;
     }
 
-    /** Gets the radius of the sphere
+    /** Gets the radius of the sphere.
      *
      * @return the radius of the sphere
      */
@@ -109,9 +114,8 @@ public class ParticleSphere extends ParticleObject {
     }
 
     /** Set the interceptor to run after drawing the sphere.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the position
-     * where the sphere is rendered.  It will also have the surface point and
-     * number of the individual particle that was just drawn.
+     * with references to the {@link ServerWorld}, the step number of the animation, the center
+     * of the sphere, and the ParticleSphere instance.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
@@ -124,10 +128,9 @@ public class ParticleSphere extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Set the interceptor to run prior to drawing the sphere.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the position
-     * where the sphere is rendered.  It will also have the number of the individual particle effect
-     * about to be drawn.
+    /** Set the interceptor to run before drawing the sphere.  The interceptor will be provided
+     * with references to the {@link ServerWorld}, the step number of the animation, the center
+     * of the sphere, and the ParticleSphere instance.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing the sphere
      */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
@@ -11,9 +11,9 @@ import org.joml.Vector3f;
 
 import java.util.Optional;
 
-/** The particle object class that represents a 3D triangle (Tetrahedron).
+/** The particle object class that represents a tetrahedron which may be irregular.
  *  It has four vertices that make it up which must not be coplanar with each other.
- *  The vertices can be set individually or by supplying a list of four vertices
+ *  The vertices can be set individually or by supplying a list of four vertices.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleTetrahedron extends ParticleObject {
@@ -33,9 +33,13 @@ public class ParticleTetrahedron extends ParticleObject {
             "Unbalanced vertices, there must be only 4 vertices"
     );
 
-    /** Constructor for the particle tetrahedron which is a 3D triangle. It accepts as parameters
-     * the particle effect to use, the vertices that connect the tetrahedron, the number of particles & the
-     * rotation to apply There is also a simplified version for no rotation.
+    /** Constructor for the particle tetrahedron. It accepts as parameters
+     * the particle effect to use, the vertices that compose the tetrahedron, the number of particles, and the
+     * rotation to apply.
+     *
+     * <p>This implementation calls setters for rotation and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
@@ -57,10 +61,12 @@ public class ParticleTetrahedron extends ParticleObject {
         this.amount = amount;
     }
 
-    /** Constructor for the particle tetrahedron which is a 3D triangle. It accepts as parameters
-     * the particle to use, the vertices that connect the tetrahedron & the number of particles.
-     * It is a simplified version for the case when no rotation is meant to be applied.
-     * For rotation offset, you can use another constructor
+    /** Constructor for the particle tetrahedron. It accepts as parameters
+     * the particle to use, the vertices that compose the tetrahedron, and the number of particles.
+     *
+     * <p>This implementation calls setters for rotation and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param vertices The vertices that make up the tetrahedron
@@ -73,16 +79,16 @@ public class ParticleTetrahedron extends ParticleObject {
     }
 
     /** The copy constructor for a specific particle object. It copies all
-     * the params, including the interceptors the particle object has
+     * the params, including the interceptors the particle object has.  Vertices are copied to new vectors.
      *
      * @param tetrahedron The particle tetrahedron object to copy from
     */
     public ParticleTetrahedron(ParticleTetrahedron tetrahedron) {
         super(tetrahedron);
-        this.vertex1 = tetrahedron.vertex1;
-        this.vertex2 = tetrahedron.vertex2;
-        this.vertex3 = tetrahedron.vertex3;
-        this.vertex4 = tetrahedron.vertex4;
+        this.vertex1 = new Vector3f(tetrahedron.vertex1);
+        this.vertex2 = new Vector3f(tetrahedron.vertex2);
+        this.vertex3 = new Vector3f(tetrahedron.vertex3);
+        this.vertex4 = new Vector3f(tetrahedron.vertex4);
         this.beforeDraw = tetrahedron.beforeDraw;
         this.afterDraw = tetrahedron.afterDraw;
     }
@@ -109,7 +115,7 @@ public class ParticleTetrahedron extends ParticleObject {
 
     /** Sets the first individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -125,7 +131,7 @@ public class ParticleTetrahedron extends ParticleObject {
 
     /** Sets the second individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -141,7 +147,7 @@ public class ParticleTetrahedron extends ParticleObject {
 
     /** Sets the third individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -157,7 +163,7 @@ public class ParticleTetrahedron extends ParticleObject {
 
     /** Sets the third individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -171,9 +177,8 @@ public class ParticleTetrahedron extends ParticleObject {
         return prevVertex4;
     }
 
-    /** Sets the individual vertices all at once if you want to set one vertex at a time,
-     * then its recommend to use the methods ``setVertex1``, ``setVertex2``... etc.
-     * The vertices have to be 4 to modify the values, it returns nothing
+    /** Sets all vertices at once.  If you want to set one vertex at a time,
+     * then it's recommended to use the methods {@link #setVertex1(Vector3f)}, etc.  Returns nothing.
      *
      * @param vertices The vertices to modify
      *
@@ -190,29 +195,37 @@ public class ParticleTetrahedron extends ParticleObject {
         this.vertex4 = vertices[3];
     }
 
-    /** Gets the first individual vertex
+    /** Gets the first individual vertex.
      *
      * @return The first individual vertex
     */
-    public Vector3f getVertex1() {return this.vertex1;}
+    public Vector3f getVertex1() {
+        return this.vertex1;
+    }
 
-    /** Gets the second individual vertex
+    /** Gets the second individual vertex.
      *
      * @return The second individual vertex
     */
-    public Vector3f getVertex2() {return this.vertex2;}
+    public Vector3f getVertex2() {
+        return this.vertex2;
+    }
 
-    /** Gets the third individual vertex
+    /** Gets the third individual vertex.
      *
      * @return The third individual vertex
     */
-    public Vector3f getVertex3() {return this.vertex3;}
+    public Vector3f getVertex3() {
+        return this.vertex3;
+    }
 
-    /** Gets the fourth individual vertex
+    /** Gets the fourth individual vertex.
      *
      * @return The fourth individual vertex
     */
-    public Vector3f getVertex4() {return this.vertex4;}
+    public Vector3f getVertex4() {
+        return this.vertex4;
+    }
 
     @Override
     public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
@@ -242,8 +255,8 @@ public class ParticleTetrahedron extends ParticleObject {
     }
 
     /** Set the interceptor to run after drawing the tetrahedron.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the position where the tetrahedron is rendered, and the
-     * step number of the animation.  There is no other data attached.
+     * with references to the {@link ServerWorld}, the position where the tetrahedron is rendered, the
+     * step number of the animation, and the ParticleTetrahedron instance.  There is no other data attached.
      *
      * @param afterDraw the new interceptor to execute prior to drawing the tetrahedron
      */
@@ -258,7 +271,7 @@ public class ParticleTetrahedron extends ParticleObject {
 
     /** Set the interceptor to run prior to drawing the tetrahedron.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the position where the tetrahedron is rendered, and the
-     * step number of the animation.  There is no other data attached.
+     * step number of the animation, and the ParticleTetrahedron instance.  There is no other data attached.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing the tetrahedron
      */

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 /** The particle object class that represents a 2D triangle.
  * It has three vertices that make it up, all of them must be coplanar with each other.
- * The vertices can be set individually or by supplying a list of four vertices
+ * The vertices can be set individually or by supplying a list of three vertices.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleTriangle extends ParticleObject {
@@ -32,9 +32,13 @@ public class ParticleTriangle extends ParticleObject {
             "Unbalanced vertices, there must be only 3 vertices"
     );
 
-    /** Constructor for the particle triangle which is a 2D shape. It accepts as parameters
-     * the particle effect to use, the vertices that connect the triangle, the number of particles & the
-     * rotation to apply There is also a simplified version for no rotation.
+    /** Constructor for the particle triangle. It accepts as parameters
+     * the particle effect to use, the vertices that compose the triangle, the number of particles, and the
+     * rotation to apply.
+     *
+     * <p>This implementation calls setters for rotation and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param amount The number of particles for the object
@@ -52,13 +56,15 @@ public class ParticleTriangle extends ParticleObject {
         this.vertex1 = vertices[0];
         this.vertex2 = vertices[1];
         this.vertex3 = vertices[2];
-        this.amount = amount;
+        this.setAmount(amount);
     }
 
-    /** Constructor for the particle triangle which is a 2D shape. It accepts as parameters
-     * the particle to use, the vertices that connect the triangle & the number of particles.
-     * It is a simplified version for the case when no rotation is meant to be applied.
-     * For rotation offset, you can use another constructor
+    /** Constructor for the particle triangle. It accepts as parameters
+     * the particle to use, the vertices that compose the triangle, and the number of particles.
+     *
+     * <p>This implementation calls setters for rotation and amount so checks are performed to
+     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
+     * they risk undefined behavior.
      *
      * @param particleEffect The particle to use
      * @param vertices The vertices that make up the triangle
@@ -71,15 +77,15 @@ public class ParticleTriangle extends ParticleObject {
     }
 
     /** The copy constructor for a specific particle object. It copies all
-     * the params, including the interceptors the particle object has
+     * the params, including the interceptors the particle object has.  Vertices are copied to new vectors.
      *
      * @param triangle The particle triangle object to copy from
     */
     public ParticleTriangle(ParticleTriangle triangle) {
         super(triangle);
-        this.vertex1 = triangle.vertex1;
-        this.vertex2 = triangle.vertex2;
-        this.vertex3 = triangle.vertex3;
+        this.vertex1 = new Vector3f(triangle.vertex1);
+        this.vertex2 = new Vector3f(triangle.vertex2);
+        this.vertex3 = new Vector3f(triangle.vertex3);
         this.beforeDraw = triangle.beforeDraw;
         this.afterDraw = triangle.afterDraw;
     }
@@ -101,7 +107,7 @@ public class ParticleTriangle extends ParticleObject {
 
     /** Sets the first individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -117,7 +123,7 @@ public class ParticleTriangle extends ParticleObject {
 
     /** Sets the second individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -133,7 +139,7 @@ public class ParticleTriangle extends ParticleObject {
 
     /** Sets the third individual vertex, it returns the previous
      * vertex that was used. If you want to modify multiple
-     * vertices at once then use {@code setVertices}
+     * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
      * @return The previous vertex
@@ -147,14 +153,12 @@ public class ParticleTriangle extends ParticleObject {
         return prevVertex3;
     }
 
-    /** Sets the individual vertices all at once given a list of the vertices.
-     * If you want to set one vertex at a time, then its recommend to use the methods ``setVertex1``,
-     * ``setVertex2``... etc. The vertices have to be 4 to modify the values.
-     * It returns nothing
+    /** Sets all vertices at once.  If you want to set one vertex at a time, then it's recommended to use
+     * {@link #setVertex1(Vector3f)}, etc.  Returns nothing.
      *
      * @param vertices The vertices to modify
      *
-     * @throws IllegalArgumentException if the number of vertices supplied isn't equal to 4
+     * @throws IllegalArgumentException if the number of vertices supplied isn't equal to 3
     */
     public void setVertices(Vector3f... vertices) {
         if (vertices.length != 3) {
@@ -166,23 +170,29 @@ public class ParticleTriangle extends ParticleObject {
         this.vertex3 = vertices[2];
     }
 
-    /** Gets the first individual vertex
+    /** Gets the first individual vertex.
      *
      * @return The first individual vertex
     */
-    public Vector3f getVertex1() {return this.vertex1;}
+    public Vector3f getVertex1() {
+        return this.vertex1;
+    }
 
-    /** Gets the second individual vertex
+    /** Gets the second individual vertex.
      *
      * @return The second individual vertex
     */
-    public Vector3f getVertex2() {return this.vertex2;}
+    public Vector3f getVertex2() {
+        return this.vertex2;
+    }
 
-    /** Gets the third individual vertex
+    /** Gets the third individual vertex.
      *
      * @return The third individual vertex
     */
-    public Vector3f getVertex3() {return this.vertex3;}
+    public Vector3f getVertex3() {
+        return this.vertex3;
+    }
 
     @Override
     public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
@@ -208,8 +218,8 @@ public class ParticleTriangle extends ParticleObject {
     }
 
     /** Set the interceptor to run after drawing the triangle.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the position where the triangle is rendered, and the
-     * step number of the animation.  There is no other data attached.
+     * with references to the {@link ServerWorld}, the position where the triangle is rendered, the
+     * step number of the animation, and the ParticleTriangle instance.
      *
      * @param afterDraw the new interceptor to execute prior to drawing the triangle
      */
@@ -223,8 +233,8 @@ public class ParticleTriangle extends ParticleObject {
     }
 
     /** Set the interceptor to run prior to drawing the triangle.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the position where the triangle is rendered, and the
-     * step number of the animation.  There is no other data attached.
+     * with references to the {@link ServerWorld}, the position where the triangle is rendered, the
+     * step number of the animation, and the ParticleTriangle instance.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing the triangle
      */


### PR DESCRIPTION
There are a few tweaks to ensure correctness around defensive copies, simplifying the cuboid width/height/depth logic and vertex order, and other similar fixes.