### PR TITLE
Re-apply ParticleCombiner fixes

### DIFF
--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
@@ -1,0 +1,73 @@
+package net.mcbrincie.apel.lib.objects;
+
+import net.minecraft.particle.ParticleEffect;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class ParticleCombinerTest {
+    // Use this to prevent having to initialize all the Minecraft Server logic
+    private static final ParticleEffect NULL_PARTICLE = null;
+
+    @Test
+    void setObjectsViaList() {
+        // Given a couple ParticlePoints
+        ParticlePoint p1 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p2 = new ParticlePoint(NULL_PARTICLE);
+
+        // Given a ParticleCombiner
+        ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
+
+        // Given points to append
+        ParticlePoint p3 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p4 = new ParticlePoint(NULL_PARTICLE);
+
+        // When the points are set
+        combiner.setObjects(List.of(p3, p4));
+        // Then the combiner has two objects
+        assertEquals(2, combiner.getObjects().size());
+    }
+
+    @Test
+    void setObjectsLeavesAppendFunctional() {
+        // Given a couple ParticlePoints
+        ParticlePoint p1 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p2 = new ParticlePoint(NULL_PARTICLE);
+
+        // Given a ParticleCombiner
+        ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
+
+        // Given a point to append
+        ParticlePoint p3 = new ParticlePoint(NULL_PARTICLE);
+
+        // When the points are set
+        combiner.setObjects(List.of(p1, p2));
+        combiner.appendObject(p3);
+
+        // Then the combiner has three objects
+        assertEquals(3, combiner.getObjects().size());
+    }
+
+    @Test
+    void appendObjects() {
+        // Given a couple ParticlePoints
+        ParticlePoint p1 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p2 = new ParticlePoint(NULL_PARTICLE);
+
+        // Given a ParticleCombiner
+        ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
+
+        // Given points to append
+        ParticlePoint p3 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p4 = new ParticlePoint(NULL_PARTICLE);
+
+        // When the points are appended
+        combiner.appendObjects(p3, p4);
+
+        // Then the combiner has four objects
+        assertEquals(4, combiner.getObjects().size());
+    }
+}


### PR DESCRIPTION
Using `Arrays.asList` (and similar methods) often results in unmodifiable lists.  This means future calls to `setObject`, `setOffset`, `appendObject`, and `appendObjects` will not work.  Handle this by creating `ArrayList`s when needed.

Remove separate offset handling.  There is no reason for `ParticleCombiner` to have separate offsets from the one already available on `ParticleObject`.  This will result in double offsets when `ParticleCombiner` applies an offset in its `draw` method prior to calling the `draw` on the child `ParticleObject`.  To maintain the convenience afforded by the combiner, the various "offset" methods delegate to those of the `ParticleObject`.

This also readds the test.  Having the tests break last time showed that the merge was not done cleanly.  The merge had conflicts, and I believe they were resolved by taking the main branch's contents instead of working through the differences.  This broke the test, which had no conflicts, but showed the correct behavior of `ParticleCombiner`.