### PR TITLE
Simplify and strengthen interceptors on ParticleObjects

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -266,7 +266,7 @@ public abstract class PathAnimatorBase {
     public void handleDrawingStep(ApelServerRenderer renderer, int step, Vector3f drawPosition) throws SeqMissingException {
         Runnable func = () -> {
             renderer.beforeFrame(step, drawPosition);
-            this.particleObject.draw(renderer, step, drawPosition);
+            this.particleObject.doDraw(renderer, step, drawPosition);
             renderer.afterFrame(step, drawPosition);
         };
         if (this.delay == 0) {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/DrawContext.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/DrawContext.java
@@ -1,0 +1,220 @@
+package net.mcbrincie.apel.lib.objects;
+
+import com.google.common.reflect.TypeToken;
+import net.minecraft.server.world.ServerWorld;
+import org.joml.Vector3f;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * DrawContext is an extensible mechanism for providing information to the
+ * {@code beforeDraw} and {@code afterDraw} interceptors defined on
+ * {@link net.mcbrincie.apel.lib.objects.ParticleObject} subclasses.  It encapsulates
+ * a few common reference points that may be useful when rendering particle-based
+ * objects that need to vary over their animation duration.
+ * <br><br>
+ * These references are the {@link ServerWorld}, the reference point from which the
+ * shape or particle is rendered, and the current animation step number.  Individual
+ * subclasses are free to add additional information that may be useful, such as
+ * vertices for polygonal or polyhedral shapes, whether child objects should be drawn
+ * (as seen in {@link net.mcbrincie.apel.lib.objects.ParticleCombiner}), and any other
+ * information they may wish to expose.  These additional fields should be exposed by
+ * using the {@link #addMetadata(Key, Object)} method so interceptors can reference
+ * them in a reasonably safe manner.
+ * <br><br>
+ * <b>Modifications:</b> Interceptors that wish to modify the values may do so by
+ * retrieving the value of interest using {@link #getMetadata(Key)}.
+ * If those changes are in-place, such as for Vector3f and other JOML classes, no further
+ * interaction with the map is required.  If the changes produce a new value, then
+ * interceptors should call {@link #addMetadata(Key, Object)} to place the updated
+ * value in the map so that the particle shape will receive it.
+ * <br><br>
+ * <b>Retrieving Values:</b> Particle objects should retrieve values using
+ * {@link #getMetadata(Key)}.  This is a generic method that will look for
+ * the value, and if found, safely cast and return it.  If a default value is desired,
+ * {@link #getMetadata(Key, Object)} accepts and returns a default value of the correct
+ * type.
+ * <br><br>
+ * <b>Warning:</b> Casting or auto-unboxing metadata values to primitive types may result in
+ * {@code NullPointerException} if the map does not have a value for the given key or
+ * if the value of the given key is {@code null}.  It is strongly recommended to use
+ * {@link #getMetadata(Key, Object)} when handling primitive types.
+ */
+public class DrawContext {
+    private final int currentStep;
+    private final Vector3f position;
+    private final ServerWorld world;
+    private final Map<Key<?>, Object> metadata;
+
+    /**
+     * Indexes metadata in the DrawContext.  Keys are equal if both their name and their type match, regardless of
+     * which actual Java class declares the Key.
+     * <br><br>
+     * Do note that equality will only work correctly if the code literally has the anonymous subclass declared
+     * with the full parameterized type.  This is due to how Java's type erasure, compile-time checking, and runtime
+     * class knowledge of what types are allowed interact.  Creating a generic factory method, like the following,
+     * <strong>will not work</strong> because Java creates a single class that accepts any type so long as the code
+     * calling it meets all type criteria.
+     * <pre>
+     * // Does not work at runtime!
+     * static &lt;R&gt; Key&lt;R&gt; keyFor(String name) {
+     *     return new Key<>(name) {};
+     * }
+     *
+     * Key&lt;Integer&gt; integerKey = Class.keyFor("property");
+     * </pre>
+     * The {@code type} of such class will be {@code R}, not whatever is declared in the variable receiving the
+     * instance ({@code Integer} in the example). Several common types have Key subclasses provided, but further
+     * Keys are available by declaring additional anonymous subclasses:
+     * <pre>
+     * DrawContext.Key&lt;Type&gt; keyOfType = new DrawContext.Key&lt;Type&gt;("keyName") {};
+     * </pre>
+     *
+     * @param <T> The type of value pointed to by this key.
+     */
+    public abstract static class Key<T> {
+        protected final String name;
+        protected TypeToken<T> type;
+
+        public Key(String name) {
+            this.name = name;
+            // Extracts the generic type from the superclass (Key, in this case)
+            this.type = new TypeToken<>(getClass()) {};
+        }
+
+        // This method typically would include "|| getClass() != o.getClass()" immediately after checking "o == null".
+        // For Key, avoid that because defining equivalent keys may happen in two different classes,
+        // since name and type are all that's required to be equivalent.  The class object itself is not
+        // important *in this specific case*.
+        @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null) {
+                return false;
+            }
+            Key<?> key = (Key<?>) o;
+            return Objects.equals(name, key.name) && Objects.equals(type, key.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, type);
+        }
+    }
+
+    // Pre-defined Key types
+
+    public static Key<Integer> integerKey(String name) {
+        return new Key<>(name) { };
+    }
+
+    public static Key<Boolean> booleanKey(String name) {
+        return new Key<>(name) { };
+    }
+
+    public static Key<ParticleObject<?>> particleObjectKey(String name) {
+        return new Key<>(name) { };
+    }
+
+    public static Key<Vector3f> vector3fKey(String name) {
+        return new Key<>(name) { };
+    }
+
+    public static Key<Vector3f[]> vector3fArrayKey(String name) {
+        return new Key<>(name) { };
+    }
+
+    @SuppressWarnings("unused")
+    public static Key<Float> floatKey(String name) {
+        return new Key<>(name) { };
+    }
+
+    // End pre-defined key types
+
+    /** Constructs an InterceptorData object to pass to an interceptor
+     *
+     * @param world the active ServerWorld reference
+     * @param position the position at which drawing will occur
+     * @param step the current animation step
+     */
+    public DrawContext(ServerWorld world, Vector3f position, int step) {
+        this.currentStep = step;
+        this.position = position;
+        this.world = world;
+        this.metadata = new HashMap<>();
+    }
+
+    /** Add metadata to the map for interceptors to use.
+     *
+     * @param value the value available to the interceptor
+     */
+    public <T> void addMetadata(Key<T> key, T value) {
+        this.metadata.put(key, value);
+    }
+
+    /**
+     * Retrieve a typed metadata value, possibly updated, from the metadata map. Callers should ensure they placed a
+     * value in the metadata before calling this, or they risk a NullPointerException upon using the result from this
+     * method.
+     *
+     * @param key the enum value identifying the metadata
+     * @param <T> the type of the key and existing value (if present)
+     * @return the value associated with the key, if present, else null
+     *
+     * @see DrawContext#getMetadata(Key, Object)
+     */
+    @SuppressWarnings({"unchecked"})
+    public <T> T getMetadata(Key<T> key) {
+        // This cast is safe because `addMetadata` ensures the key and value types match at compile-time
+        return (T) this.metadata.get(key);
+    }
+
+    /**
+     * Retrieve a typed metadata value, possibly updated, from the metadata map. This method can safely use primitive
+     * values as defaults, since ensuring a non-null default value means auto-unboxing will succeed. Callers should
+     * ensure their default value's type is the type they want to receive from this method.
+     *
+     * @param key the enum value identifying the metadata
+     * @param defaultValue the default value to be returned if no value exists, or the value is null
+     * @param <T> the type of the key, existing value (if present), and default value
+     * @return the value associated with the key, if present, else the default value
+     *
+     * @see DrawContext#getMetadata(Key)
+     */
+    @SuppressWarnings("unused")
+    public <T> T getMetadata(Key<T> key, T defaultValue) {
+        return Optional.ofNullable(this.getMetadata(key)).orElse(requireNonNull(defaultValue));
+    }
+
+    /** Get the current step of the animation this object is in.
+     *
+     * @return the current step of the animation
+     */
+    public int getCurrentStep() {
+        return currentStep;
+    }
+
+    /** Get the position from which the current shape's rendering is computed
+     *
+     * @return the position from which the current shape's rendering is computed
+     */
+    public Vector3f getPosition() {
+        return position;
+    }
+
+    /** Get the active Minecraft ServerWorld
+     *
+     * @return the active Minecraft ServerWorld
+     */
+    public ServerWorld getWorld() {
+        return world;
+    }
+}

--- a/src/main/java/net/mcbrincie/apel/lib/objects/DrawInterceptor.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/DrawInterceptor.java
@@ -12,13 +12,14 @@ package net.mcbrincie.apel.lib.objects;
  * an offset, changing a vertex, and so on.  The {@link DrawContext} parameter
  * will contain additional useful information for the point at which the intercept
  * occurs, and modifications to that information are also done in-place via its
- * {@link DrawContext#getMetadata(String, Object)} and
- * {@link DrawContext#addMetadata(String, Object)} methods to retrieve and update
- * metadata values, respectively.
- * @param <T> The type being intercepted
+ * {@link DrawContext#getMetadata(DrawContext.Key, Object)} and
+ * {@link DrawContext#addMetadata(DrawContext.Key, Object)} methods to retrieve and
+ * update metadata values, respectively.
+ *
+ * @param <T> The ParticleObject type being intercepted
  */
 @FunctionalInterface
-public interface DrawInterceptor<T> {
+public interface DrawInterceptor<T extends ParticleObject<T>> {
     /** Apply the interceptor.
      * <br><br>
      * Return values are sent via the {@code InterceptData}'s metadata map.
@@ -26,14 +27,14 @@ public interface DrawInterceptor<T> {
      * @param data metadata useful within the interceptor
      * @param obj the object being intercepted
      */
-    void apply(DrawContext data, ParticleObject<T> obj);
+    void apply(DrawContext data, T obj);
 
     /** An identity interceptor that does nothing.  May be used when clearing an
      * interceptor.
      * @return the identity interceptor
      * @param <T> The type being intercepted
      */
-    static <T> DrawInterceptor<T> identity() {
+    static <T extends ParticleObject<T>> DrawInterceptor<T> identity() {
         return (data, object) -> {};
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/DrawInterceptor.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/DrawInterceptor.java
@@ -1,0 +1,39 @@
+package net.mcbrincie.apel.lib.objects;
+
+/** DrawInterceptor defines the signature for interceptor methods in APEL.
+ * At several points in the library, Apel allows developers to inject custom
+ * handling.  There are two options in these situations: provide an implementation
+ * of this functional interface as either a lambda or a class instance, or provide
+ * nothing and have the {@link #identity()} implementation be called.
+ * <br><br>
+ * Callers can expect to be passed the object on which the interception is occurring
+ * and a set of metadata that may be useful within the interceptor.  Many updates
+ * to the object being intercepted are in-place such as setting rotation, modifying
+ * an offset, changing a vertex, and so on.  The {@link DrawContext} parameter
+ * will contain additional useful information for the point at which the intercept
+ * occurs, and modifications to that information are also done in-place via its
+ * {@link DrawContext#getMetadata(String, Object)} and
+ * {@link DrawContext#addMetadata(String, Object)} methods to retrieve and update
+ * metadata values, respectively.
+ * @param <T> The type being intercepted
+ */
+@FunctionalInterface
+public interface DrawInterceptor<T> {
+    /** Apply the interceptor.
+     * <br><br>
+     * Return values are sent via the {@code InterceptData}'s metadata map.
+     *
+     * @param data metadata useful within the interceptor
+     * @param obj the object being intercepted
+     */
+    void apply(DrawContext data, ParticleObject<T> obj);
+
+    /** An identity interceptor that does nothing.  May be used when clearing an
+     * interceptor.
+     * @return the identity interceptor
+     * @param <T> The type being intercepted
+     */
+    static <T> DrawInterceptor<T> identity() {
+        return (data, object) -> {};
+    }
+}

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
@@ -1,12 +1,7 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
-import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
-
-import java.util.Optional;
 
 /** The particle object class that represents a circle (2D shape) and not a 3D sphere.
  * It has a radius which dictates how large or small the circle is depending on the
@@ -16,31 +11,17 @@ import java.util.Optional;
  * angles for rotation.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleCircle extends ParticleObject {
+public class ParticleCircle extends ParticleObject<ParticleCircle> {
     protected float radius;
 
-    private DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw;
-    private DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw;
-
-    /** This data is used before calculations (it contains the iterated rotation) */
-    public enum BeforeDrawData {}
-
-    /** This data is used after calculations (it contains the drawing position) */
-    public enum AfterDrawData {}
-
-    /**
-     * Provide a builder instance.
-     * @return A builder instance
-     */
     public static Builder<?> builder() {
         return new Builder<>();
     }
 
     private ParticleCircle(Builder<?> builder) {
-        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount, builder.beforeDraw,
+              builder.afterDraw);
         this.setRadius(builder.radius);
-        this.setBeforeDraw(builder.beforeDraw);
-        this.setAfterDraw(builder.afterDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -51,8 +32,6 @@ public class ParticleCircle extends ParticleObject {
     public ParticleCircle(ParticleCircle circle) {
         super(circle);
         this.radius = circle.radius;
-        this.afterDraw = circle.afterDraw;
-        this.beforeDraw = circle.beforeDraw;
     }
 
     /** Gets the radius of the ParticleCircle and returns it.
@@ -81,55 +60,16 @@ public class ParticleCircle extends ParticleObject {
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
-        this.doBeforeDraw(renderer.getServerWorld(), step, drawPos);
-        Vector3f objectDrawPos = new Vector3f(drawPos).add(this.offset);
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
         renderer.drawEllipse(
-                this.particleEffect, step, objectDrawPos, this.radius, this.radius, this.rotation, this.amount);
-        this.doAfterDraw(renderer.getServerWorld(), step, drawPos);
-        this.endDraw(renderer, step, drawPos);
+                this.particleEffect, drawContext.getCurrentStep(), objectDrawPos, this.radius, this.radius,
+                this.rotation, this.amount
+        );
     }
 
-    /**
-     * Set the interceptor to run after drawing the circle.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position of the center of the circle.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param afterDraw the new interceptor to execute after drawing each particle
-     */
-    public void setAfterDraw(DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw) {
-        this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doAfterDraw(ServerWorld world, int step, Vector3f centerPos) {
-        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, centerPos, step, AfterDrawData.class);
-        this.afterDraw.apply(interceptData, this);
-    }
-
-    /**
-     * Set the interceptor to run prior to drawing the circle.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position of the center of the circle.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param beforeDraw the new interceptor to execute prior to drawing each particle
-     */
-    public void setBeforeDraw(DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw) {
-        this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doBeforeDraw(ServerWorld world, int step, Vector3f pos) {
-        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, pos, step, BeforeDrawData.class);
-        this.beforeDraw.apply(interceptData, this);
-    }
-
-    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleCircle> {
         protected float radius;
-        protected DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw;
-        protected DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw;
 
         private Builder() {}
 
@@ -138,28 +78,6 @@ public class ParticleCircle extends ParticleObject {
          */
         public B radius(float radius) {
             this.radius = radius;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleCircle#setAfterDraw(DrawInterceptor)
-         */
-        public B afterDraw(DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw) {
-            this.afterDraw = afterDraw;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleCircle#setBeforeDraw(DrawInterceptor)
-         */
-        public B beforeDraw(DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw) {
-            this.beforeDraw = beforeDraw;
             return self();
         }
 

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCone.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCone.java
@@ -1,42 +1,26 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
-import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
-
-import java.util.Optional;
 
 /** The particle object class that represents a 3D shape(a cone).
  * It requires a height value which dictates how tall the cone is as well as
  * the maximum radius, it also accepts rotation for the cone
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleCone extends ParticleObject {
+public class ParticleCone extends ParticleObject<ParticleCone> {
     protected float height;
     protected float radius;
 
-    private DrawInterceptor<ParticleCone, AfterDrawData> afterDraw;
-    private DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw;
-
-    public enum BeforeDrawData {}
-    public enum AfterDrawData {}
-
-    /**
-     * Provide a builder instance.
-     * @return A builder instance
-     */
     public static Builder<?> builder() {
         return new Builder<>();
     }
 
     private ParticleCone(Builder<?> builder) {
-        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount, builder.beforeDraw,
+              builder.afterDraw);
         this.setHeight(builder.height);
         this.setRadius(builder.radius);
-        this.setAfterDraw(builder.afterDraw);
-        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -48,8 +32,6 @@ public class ParticleCone extends ParticleObject {
         super(cone);
         this.height = cone.height;
         this.radius = cone.radius;
-        this.beforeDraw = cone.beforeDraw;
-        this.afterDraw = cone.afterDraw;
     }
 
     /** Gets the height of the cone
@@ -97,49 +79,17 @@ public class ParticleCone extends ParticleObject {
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
-        this.doBeforeDraw(renderer.getServerWorld(), step);
-        Vector3f objectDrawPos = new Vector3f(drawPos).add(this.offset);
-        renderer.drawCone(this.particleEffect, step, objectDrawPos, this.height, this.radius, this.rotation, this.amount);
-        this.doAfterDraw(renderer.getServerWorld(), step);
-        this.endDraw(renderer, step, drawPos);
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
+        renderer.drawCone(
+                this.particleEffect, drawContext.getCurrentStep(), objectDrawPos, this.height, this.radius,
+                this.rotation, this.amount
+        );
     }
 
-    /** Sets the interceptor to run after drawing the cone. The interceptor will be provided
-     * with references to the {@link ServerWorld}, the animation step number, and the ParticleCone
-     * instance.
-     *
-     * @param afterDraw the new interceptor to execute after drawing the cone
-     */
-    public void setAfterDraw(DrawInterceptor<ParticleCone, AfterDrawData> afterDraw) {
-        this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doAfterDraw(ServerWorld world, int step) {
-        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, null, step, AfterDrawData.class);
-        this.afterDraw.apply(interceptData, this);
-    }
-
-    /** Set the interceptor to run before drawing the cone. The interceptor will be provided
-     * with references to the {@link ServerWorld}, the animation step number, and the ParticleCone
-     * instance.
-     *
-     * @param beforeDraw the new interceptor to execute before drawing the cone
-     */
-    public void setBeforeDraw(DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw) {
-        this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doBeforeDraw(ServerWorld world, int step) {
-        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, null, step, BeforeDrawData.class);
-        this.beforeDraw.apply(interceptData, this);
-    }
-
-    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleCone> {
         protected float height;
         protected float radius;
-        protected DrawInterceptor<ParticleCone, AfterDrawData> afterDraw;
-        protected DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw;
 
         private Builder() {}
 
@@ -156,28 +106,6 @@ public class ParticleCone extends ParticleObject {
          */
         public B radius(float radius) {
             this.radius = radius;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleCone#setAfterDraw(DrawInterceptor)
-         */
-        public B afterDraw(DrawInterceptor<ParticleCone, AfterDrawData> afterDraw) {
-            this.afterDraw = afterDraw;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleCone#setBeforeDraw(DrawInterceptor)
-         */
-        public B beforeDraw(DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw) {
-            this.beforeDraw = beforeDraw;
             return self();
         }
 

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -1,15 +1,10 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
-import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.server.world.ServerWorld;
 import org.joml.Quaternionf;
 import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
-
-import java.util.Optional;
 
 /** The particle object class that represents a cuboid which is a rectangle
  * living in 3D. It is a cube if all the values of the size vector
@@ -20,47 +15,38 @@ import java.util.Optional;
  * {@link #setAmount(Vector3i)}.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleCuboid extends ParticleObject {
-    protected Vector3f size;
-    protected Vector3i amount;
+public class ParticleCuboid extends ParticleObject<ParticleCuboid> {
+    protected Vector3f size = new Vector3f();
+    protected Vector3i amount = new Vector3i();
 
-    private DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw;
-    private DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw;
+    /**
+     * The vertices provided follow this indexing scheme (using Minecraft's axes where +x is east, +y is up, and
+     * +z is south), but will be rotated and translated prior to the interceptor:
+     *
+     * <pre>
+     *               y         z
+     *               ^        ↗
+     *               |       /
+     *          5----|--------6
+     *         /|    |     / /|
+     *        / |    |    / / |
+     *       /  |    |   / /  |
+     *      4-------------7   +
+     *      |   |    | /  |   |
+     *      |   |    |/   |   |
+     * x <--|--------+    |   |
+     *      |   |         |   |
+     *      |   |         |   |
+     *      |   1---------|---2
+     *      |  /          |  /
+     *      | /           | /
+     *      |/            |/
+     *      0-------------3
+     * </pre>
+     */
+    public static final DrawContext.Key<Vector3f[]> VERTICES = DrawContext.vector3fArrayKey("vertices");
 
-    /** There is no data being transmitted */
-    public enum AfterDrawData {}
-
-    /** This data is used before calculations (it contains the vertices)*/
-    public enum BeforeDrawData {
-        /**
-         * The vertices provided follow this indexing scheme (using Minecraft's axes where +x is east, +y is up, and
-         * +z is south), but will be rotated and translated prior to the interceptor:
-         *
-         * <pre>
-         *               y         z
-         *               ^        ↗
-         *               |       /
-         *          5----|--------6
-         *         /|    |     / /|
-         *        / |    |    / / |
-         *       /  |    |   / /  |
-         *      4-------------7   +
-         *      |   |    | /  |   |
-         *      |   |    |/   |   |
-         * x <--|--------+    |   |
-         *      |   |         |   |
-         *      |   |         |   |
-         *      |   1---------|---2
-         *      |  /          |  /
-         *      | /           | /
-         *      |/            |/
-         *      0-------------3
-         * </pre>
-         */
-        VERTICES,
-    }
-
-    /** This enum is used for the getter method of setAmount */
+    /** This enum is used when retrieving amounts used to render the cuboid. */
     public enum AreaLabel {
         BOTTOM_FACE, TOP_FACE, VERTICAL_BARS, ALL_FACES
     }
@@ -70,12 +56,10 @@ public class ParticleCuboid extends ParticleObject {
     }
 
     private ParticleCuboid(Builder<?> builder) {
-        super(builder.particleEffect, builder.rotation, builder.offset, 1);
+        super(builder.particleEffect, builder.rotation, builder.offset, 1, builder.beforeDraw, builder.afterDraw);
         // Defensive copies are made in setters to protect against in-place modification of vectors
         this.setSize(builder.size);
         this.setAmount(builder.amount);
-        this.setAfterDraw(builder.afterDraw);
-        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -87,8 +71,6 @@ public class ParticleCuboid extends ParticleObject {
         super(cuboid);
         this.size = new Vector3f(cuboid.size);
         this.amount = new Vector3i(cuboid.amount);
-        this.beforeDraw = cuboid.beforeDraw;
-        this.afterDraw = cuboid.afterDraw;
     }
 
     public Vector3f getSize() {
@@ -175,7 +157,7 @@ public class ParticleCuboid extends ParticleObject {
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
+    protected void prepareContext(DrawContext drawContext) {
         // Scale
         float width = size.x / 2f;
         float height = size.y / 2f;
@@ -184,7 +166,7 @@ public class ParticleCuboid extends ParticleObject {
         Quaternionfc quaternion =
                 new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
         // Translation
-        Vector3f objectDrawPos = new Vector3f(drawPos).add(this.offset);
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
         // Compute the cuboid vertices
         Vector3f vertex0 = this.rigidTransformation(width, -height, -depth, quaternion, objectDrawPos);
         Vector3f vertex1 = this.rigidTransformation(width, -height, depth, quaternion, objectDrawPos);
@@ -196,18 +178,23 @@ public class ParticleCuboid extends ParticleObject {
         Vector3f vertex7 = this.rigidTransformation(-width, height, -depth, quaternion, objectDrawPos);
 
         Vector3f[] vertices = {vertex0, vertex1, vertex2, vertex3, vertex4, vertex5, vertex6, vertex7};
-        InterceptData<BeforeDrawData> interceptData = this.doBeforeDraw(renderer.getServerWorld(), step, vertices);
-        vertices = interceptData.getMetadata(BeforeDrawData.VERTICES, vertices);
+        drawContext.addMetadata(VERTICES, vertices);
+    }
 
-        vertex0 = vertices[0];
-        vertex1 = vertices[1];
-        vertex2 = vertices[2];
-        vertex3 = vertices[3];
-        vertex4 = vertices[4];
-        vertex5 = vertices[5];
-        vertex6 = vertices[6];
-        vertex7 = vertices[7];
+    @Override
+    public void draw(ApelServerRenderer renderer, DrawContext data) {
+        Vector3f[] vertices = data.getMetadata(VERTICES);
 
+        Vector3f vertex0 = vertices[0];
+        Vector3f vertex1 = vertices[1];
+        Vector3f vertex2 = vertices[2];
+        Vector3f vertex3 = vertices[3];
+        Vector3f vertex4 = vertices[4];
+        Vector3f vertex5 = vertices[5];
+        Vector3f vertex6 = vertices[6];
+        Vector3f vertex7 = vertices[7];
+
+        int step = data.getCurrentStep();
         int bottomFaceAmount = this.amount.x;
         int topFaceAmount = this.amount.y;
         int verticalBarsAmount = this.amount.z;
@@ -229,53 +216,11 @@ public class ParticleCuboid extends ParticleObject {
         renderer.drawLine(this.particleEffect, step, vertex1, vertex5, verticalBarsAmount);
         renderer.drawLine(this.particleEffect, step, vertex2, vertex6, verticalBarsAmount);
         renderer.drawLine(this.particleEffect, step, vertex3, vertex7, verticalBarsAmount);
-
-        this.doAfterDraw(renderer.getServerWorld(), step);
-        this.endDraw(renderer, step, drawPos);
     }
 
-    /**
-     * Set the interceptor to run after drawing the cuboid.  The interceptor will be provided
-     * with references to the {@link ServerWorld} and the step number of the animation.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param afterDraw the new interceptor to execute after drawing each particle
-     */
-    public final void setAfterDraw(DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw) {
-        this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doAfterDraw(ServerWorld world, int step) {
-        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, null, step, AfterDrawData.class);
-        this.afterDraw.apply(interceptData, this);
-    }
-
-    /**
-     * Set the interceptor to run prior to drawing the cuboid.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * vertices of the cuboid.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param beforeDraw the new interceptor to execute prior to drawing each particle
-     */
-    public final void setBeforeDraw(DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw) {
-        this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private InterceptData<BeforeDrawData> doBeforeDraw(ServerWorld world, int step, Vector3f[] vertices) {
-        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, null, step, BeforeDrawData.class);
-        interceptData.addMetadata(BeforeDrawData.VERTICES, vertices);
-        this.beforeDraw.apply(interceptData, this);
-        return interceptData;
-    }
-
-    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleCuboid> {
         protected Vector3f size = new Vector3f();
         protected Vector3i amount = new Vector3i();
-        protected DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw;
-        protected DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw;
 
         private Builder() {}
 
@@ -310,28 +255,6 @@ public class ParticleCuboid extends ParticleObject {
         @Override
         public B amount(int amount) {
             this.amount = new Vector3i(amount, amount, amount);
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleCuboid#setAfterDraw(DrawInterceptor)
-         */
-        public B afterDraw(DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw) {
-            this.afterDraw = afterDraw;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleCuboid#setBeforeDraw(DrawInterceptor)
-         */
-        public B beforeDraw(DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw) {
-            this.beforeDraw = beforeDraw;
             return self();
         }
 

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipse.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipse.java
@@ -1,14 +1,7 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
-import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.particle.ParticleEffect;
-import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
-
-import java.util.Optional;
 
 /** The particle object class that represents an ellipse.
  * It has a radius which dictates how large or small the ellipse is depending on the
@@ -18,29 +11,19 @@ import java.util.Optional;
  * drawn in the xy-plane by default, though rotations can move it around.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleEllipse extends ParticleObject {
+public class ParticleEllipse extends ParticleObject<ParticleEllipse> {
     protected float radius;
     protected float stretch;
-
-    private DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw;
-    private DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw;
-
-    /** This data is used before calculations */
-    public enum BeforeDrawData {}
-
-    /** This data is used after calculations */
-    public enum AfterDrawData {}
 
     public static Builder<?> builder() {
         return new Builder<>();
     }
 
     private ParticleEllipse(Builder<?> builder) {
-        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount, builder.beforeDraw,
+              builder.afterDraw);
         this.setRadius(builder.radius);
         this.setStretch(builder.stretch);
-        this.setAfterDraw(builder.afterDraw);
-        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -52,8 +35,6 @@ public class ParticleEllipse extends ParticleObject {
         super(ellipse);
         this.radius = ellipse.radius;
         this.stretch = ellipse.stretch;
-        this.beforeDraw = ellipse.beforeDraw;
-        this.afterDraw = ellipse.afterDraw;
     }
 
     /** Gets the radius of the ParticleEllipse and returns it.
@@ -107,56 +88,17 @@ public class ParticleEllipse extends ParticleObject {
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
-        this.doBeforeDraw(renderer.getServerWorld(), step, drawPos);
-        Vector3f objectDrawPos = new Vector3f(drawPos).add(this.offset);
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
         renderer.drawEllipse(
-                this.particleEffect, step, objectDrawPos, this.radius, this.stretch, this.rotation, this.amount);
-        this.doAfterDraw(renderer.getServerWorld(), step, drawPos);
-        this.endDraw(renderer, step, drawPos);
+                this.particleEffect, drawContext.getCurrentStep(), objectDrawPos, this.radius, this.stretch,
+                this.rotation, this.amount
+        );
     }
 
-    /**
-     * Set the interceptor to run after drawing the ellipse. The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position of the center of the ellipse.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param afterDraw the new interceptor to execute after drawing each particle
-     */
-    public final void setAfterDraw(DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw) {
-        this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doAfterDraw(ServerWorld world, int step, Vector3f drawPos) {
-        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, drawPos, step, AfterDrawData.class);
-        this.afterDraw.apply(interceptData, this);
-    }
-
-    /**
-     * Set the interceptor to run prior to drawing the ellipse. The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, and the
-     * position of the center of the ellipse.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param beforeDraw the new interceptor to execute prior to drawing each particle
-     */
-    public final void setBeforeDraw(DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw) {
-        this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doBeforeDraw(ServerWorld world, int step, Vector3f pos) {
-        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, pos, step, BeforeDrawData.class);
-        this.beforeDraw.apply(interceptData, this);
-    }
-
-    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleEllipse> {
         protected float radius;
         protected float stretch;
-        protected DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw;
-        protected DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw;
 
         private Builder() {}
 
@@ -173,28 +115,6 @@ public class ParticleEllipse extends ParticleObject {
          */
         public B stretch(float stretch) {
             this.stretch = stretch;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleEllipse#setAfterDraw(DrawInterceptor)
-         */
-        public B afterDraw(DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw) {
-            this.afterDraw = afterDraw;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleEllipse#setBeforeDraw(DrawInterceptor)
-         */
-        public B beforeDraw(DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw) {
-            this.beforeDraw = beforeDraw;
             return self();
         }
 

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleImage.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleImage.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
  * some known issues as well as being unoptimized
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleImage extends ParticleObject {
+public class ParticleImage extends ParticleObject<ParticleImage> {
     private String filename;
     private BufferedImage image;
     private boolean transparency = false;
@@ -30,7 +30,7 @@ public class ParticleImage extends ParticleObject {
     private HashMap<Vector3f, ParticleEffect> positions;
 
     public ParticleImage(String filename, Vector3f rotation) {
-        super(null, rotation, new Vector3f(0), 1);
+        super(null, rotation, new Vector3f(0), 1, DrawInterceptor.identity(), DrawInterceptor.identity());
         this.setFilename(filename);
     }
 
@@ -89,15 +89,15 @@ public class ParticleImage extends ParticleObject {
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
         int width = this.image.getWidth();
         int height = this.image.getHeight();
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 int rgba = this.rgbArray[y * width + x];
                 int alpha = (rgba >> 24) & 0xff;
-                ParticleEffect particle = this.palateGenerator.apply(rgba, x, y, drawPos);
-                Vector3f pos = drawPos.add(x, y, 0).mul(0.01f);
+                ParticleEffect particle = this.palateGenerator.apply(rgba, x, y, drawContext.getPosition());
+                Vector3f pos = new Vector3f(drawContext.getPosition()).add(x, y, 0).mul(0.01f);
                 // this.drawParticle(particle, renderer, step, pos);
             }
         }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
@@ -1,12 +1,7 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
-import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
-
-import java.util.Optional;
 
 /** The particle object class that represents a 2D line. It is one of the
  * most simple objects to use as it needs only a start & an ending position
@@ -16,26 +11,19 @@ import java.util.Optional;
  * any difference.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleLine extends ParticleObject {
+public class ParticleLine extends ParticleObject<ParticleLine> {
     protected Vector3f start;
     protected Vector3f end;
-
-    private DrawInterceptor<ParticleLine, AfterDrawData> afterDraw;
-    private DrawInterceptor<ParticleLine, BeforeDrawData> beforeDraw;
-
-    public enum BeforeDrawData {}
-    public enum AfterDrawData {}
 
     public static Builder<?> builder() {
         return new Builder<>();
     }
 
     private ParticleLine(Builder<?> builder) {
-        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount, builder.beforeDraw,
+              builder.afterDraw);
         this.setStart(builder.start);
         this.setEnd(builder.end);
-        this.setAfterDraw(builder.afterDraw);
-        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -48,8 +36,6 @@ public class ParticleLine extends ParticleObject {
         super(line);
         this.start = new Vector3f(line.start);
         this.end = new Vector3f(line.end);
-        this.afterDraw = line.afterDraw;
-        this.beforeDraw = line.beforeDraw;
     }
 
     /** Gets the starting endpoint
@@ -110,59 +96,17 @@ public class ParticleLine extends ParticleObject {
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
-        this.doBeforeDraw(renderer.getServerWorld(), step);
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
 
-        Vector3f v1 = new Vector3f(this.start).add(drawPos).add(this.offset);
-        Vector3f v2 = new Vector3f(this.end).add(drawPos).add(this.offset);
+        Vector3f v1 = new Vector3f(this.start).add(drawContext.getPosition()).add(this.offset);
+        Vector3f v2 = new Vector3f(this.end).add(drawContext.getPosition()).add(this.offset);
 
-        renderer.drawLine(this.particleEffect, step, v1, v2, this.amount);
-
-        this.doAfterDraw(renderer.getServerWorld(), step);
-        this.endDraw(renderer, step, drawPos);
+        renderer.drawLine(this.particleEffect, drawContext.getCurrentStep(), v1, v2, this.amount);
     }
 
-    /**
-     * Set the interceptor to run after drawing the line.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the animation step number, and the ParticleLine
-     * instance.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param afterDraw the new interceptor to execute after drawing the line
-     */
-    public final void setAfterDraw(DrawInterceptor<ParticleLine, AfterDrawData> afterDraw) {
-        this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doAfterDraw(ServerWorld world, int step) {
-        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, null, step, AfterDrawData.class);
-        this.afterDraw.apply(interceptData, this);
-    }
-
-    /**
-     * Set the interceptor to run before drawing the line.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the animation step number, and the ParticleLine
-     * instance.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param beforeDraw the new interceptor to execute before drawing the line
-     */
-    public final void setBeforeDraw(DrawInterceptor<ParticleLine, BeforeDrawData> beforeDraw) {
-        this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doBeforeDraw(ServerWorld world, int step) {
-        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, null, step, BeforeDrawData.class);
-        this.beforeDraw.apply(interceptData, this);
-    }
-
-    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleLine> {
         protected Vector3f start = new Vector3f();
         protected Vector3f end = new Vector3f();
-        protected DrawInterceptor<ParticleLine, AfterDrawData> afterDraw;
-        protected DrawInterceptor<ParticleLine, BeforeDrawData> beforeDraw;
 
         private Builder() {}
 
@@ -179,28 +123,6 @@ public class ParticleLine extends ParticleObject {
          */
         public B end(Vector3f end) {
             this.end = end;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleLine#setAfterDraw(DrawInterceptor)
-         */
-        public B afterDraw(DrawInterceptor<ParticleLine, AfterDrawData> afterDraw) {
-            this.afterDraw = afterDraw;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleLine#setBeforeDraw(DrawInterceptor)
-         */
-        public B beforeDraw(DrawInterceptor<ParticleLine, BeforeDrawData> beforeDraw) {
-            this.beforeDraw = beforeDraw;
             return self();
         }
 

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePoint.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePoint.java
@@ -1,39 +1,29 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
-import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
-
-import java.util.Optional;
 
 
 /**
  * ParticlePoint allows for single particles to be rendered.  It will generally be used in conjunction
  * with other ParticleObjects, likely as part of a ParticleCombiner.  As a single point, scaling and rotation
  * do not apply, since Minecraft will render all particles facing the camera.  By default, it will be drawn
- * at the {@code drawPos} in the {@link #draw(ApelServerRenderer, int, Vector3f)} method.  Translation is possible
+ * at the {@code drawPos} in the {@link #draw(ApelServerRenderer, DrawContext)} method.  Translation is possible
  * using {@link #setOffset(Vector3f)}.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticlePoint extends ParticleObject {
-    private DrawInterceptor<ParticlePoint, AfterDrawData> afterDraw;
-    private DrawInterceptor<ParticlePoint, BeforeDrawData> beforeDraw;
+public class ParticlePoint extends ParticleObject<ParticlePoint> {
 
-    public enum BeforeDrawData {
-        DRAW_POSITION
-    }
-    public enum AfterDrawData {}
+    public static final DrawContext.Key<Vector3f> DRAW_POSITION = DrawContext.vector3fKey("drawPosition");
 
     public static Builder<?> builder() {
         return new Builder<>();
     }
 
     private ParticlePoint(Builder<?> builder) {
-        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
-        this.setAfterDraw(builder.afterDraw);
-        this.setBeforeDraw(builder.beforeDraw);
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount, builder.beforeDraw,
+              builder.afterDraw
+        );
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -43,83 +33,23 @@ public class ParticlePoint extends ParticleObject {
      */
     public ParticlePoint(ParticlePoint object) {
         super(object);
-        this.beforeDraw = object.beforeDraw;
-        this.afterDraw = object.afterDraw;
     }
 
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
-        InterceptData<BeforeDrawData> interceptData = this.doBeforeDraw(renderer.getServerWorld(), drawPos, step);
-        Vector3f objectDrawPosition = interceptData.getMetadata(BeforeDrawData.DRAW_POSITION, drawPos);
-        renderer.drawParticle(this.particleEffect, step, objectDrawPosition.add(this.offset));
-        this.doAfterDraw(renderer.getServerWorld(), objectDrawPosition, step);
-        this.endDraw(renderer, step, objectDrawPosition);
+    @Override
+    protected void prepareContext(DrawContext drawContext) {
+        drawContext.addMetadata(DRAW_POSITION, drawContext.getPosition());
     }
 
-    /**
-     * Set the interceptor to run before drawing the cone. The interceptor will be provided
-     * with references to the {@link ServerWorld}, the animation step number, and the ParticlePoint
-     * instance.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param afterDraw The new interceptor to use
-    */
-    public final void setAfterDraw(DrawInterceptor<ParticlePoint, AfterDrawData> afterDraw) {
-        this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
+        Vector3f objectDrawPosition = drawContext.getMetadata(DRAW_POSITION); //, drawContext.getPosition());
+        renderer.drawParticle(this.particleEffect, drawContext.getCurrentStep(), objectDrawPosition.add(this.offset));
     }
 
-    private void doAfterDraw(ServerWorld world, Vector3f drawPos, int step) {
-        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, drawPos, step, AfterDrawData.class);
-        this.afterDraw.apply(interceptData, this);
-    }
-
-    /**
-     * Set the interceptor to run before drawing the cone. The interceptor will be provided
-     * with references to the {@link ServerWorld}, the animation step number, and the ParticlePoint
-     * instance.  The metadata will include the drawing position.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param beforeDraw The new interceptor to use
-     */
-    public final void setBeforeDraw(DrawInterceptor<ParticlePoint, BeforeDrawData> beforeDraw) {
-        this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private InterceptData<BeforeDrawData> doBeforeDraw(ServerWorld world, Vector3f drawPos, int step) {
-        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, drawPos, step, BeforeDrawData.class);
-        interceptData.addMetadata(BeforeDrawData.DRAW_POSITION, drawPos);
-        this.beforeDraw.apply(interceptData, this);
-        return interceptData;
-    }
-
-    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
-        protected DrawInterceptor<ParticlePoint, AfterDrawData> afterDraw;
-        protected DrawInterceptor<ParticlePoint, BeforeDrawData> beforeDraw;
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticlePoint> {
+        protected DrawInterceptor<ParticlePoint> afterDraw;
+        protected DrawInterceptor<ParticlePoint> beforeDraw;
 
         private Builder() {}
-
-        /**
-         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticlePoint#setAfterDraw(DrawInterceptor)
-         */
-        public B afterDraw(DrawInterceptor<ParticlePoint, AfterDrawData> afterDraw) {
-            this.afterDraw = afterDraw;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticlePoint#setBeforeDraw(DrawInterceptor)
-         */
-        public B beforeDraw(DrawInterceptor<ParticlePoint, BeforeDrawData> beforeDraw) {
-            this.beforeDraw = beforeDraw;
-            return self();
-        }
 
         @Override
         public ParticlePoint build() {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleSphere.java
@@ -1,41 +1,25 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
-import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.particle.ParticleEffect;
-import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
-
-import java.util.Optional;
 
 /** The particle object class that represents a sphere.
  * It has a radius which dictates how large or small the sphere is.  It projects the <em>golden spiral</em>
  * on to the sphere to distribute particles evenly across the surface.
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class ParticleSphere extends ParticleObject {
+public class ParticleSphere extends ParticleObject<ParticleSphere> {
     public static final double SQRT_5_PLUS_1 = 3.23606;
     protected float radius;
-
-    private DrawInterceptor<ParticleSphere, AfterDrawData> afterDraw;
-    private DrawInterceptor<ParticleSphere, BeforeDrawData> beforeDraw;
-
-    /** This data is used before calculations */
-    public enum BeforeDrawData {}
-
-    /** This data is used after calculations */
-    public enum AfterDrawData {}
 
     public static Builder<?> builder() {
         return new Builder<>();
     }
 
     private ParticleSphere(Builder<?> builder) {
-        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount, builder.beforeDraw,
+              builder.afterDraw);
         this.setRadius(builder.radius);
-        this.setAfterDraw(builder.afterDraw);
-        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -46,8 +30,6 @@ public class ParticleSphere extends ParticleObject {
     public ParticleSphere(ParticleSphere sphere) {
         super(sphere);
         this.radius = sphere.radius;
-        this.afterDraw = sphere.afterDraw;
-        this.beforeDraw = sphere.beforeDraw;
     }
 
     /**
@@ -76,57 +58,15 @@ public class ParticleSphere extends ParticleObject {
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
-        this.doBeforeDraw(renderer.getServerWorld(), step, drawPos);
-        Vector3f objectDrawPos = new Vector3f(drawPos).add(this.offset);
-        renderer.drawEllipsoid(
-                this.particleEffect, step, objectDrawPos, this.radius, this.radius, this.radius, this.rotation,
-                this.amount
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
+        renderer.drawEllipsoid(this.particleEffect, drawContext.getCurrentStep(), objectDrawPos, this.radius,
+                               this.radius, this.radius, this.rotation, this.amount
         );
-        this.doAfterDraw(renderer.getServerWorld(), step, drawPos);
-        this.endDraw(renderer, step, drawPos);
     }
 
-    /**
-     * Set the interceptor to run after drawing the sphere.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, the center
-     * of the sphere, and the ParticleSphere instance.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param afterDraw the new interceptor to execute after drawing each particle
-     */
-    public final void setAfterDraw(DrawInterceptor<ParticleSphere, AfterDrawData> afterDraw) {
-        this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doAfterDraw(ServerWorld world, int step, Vector3f drawPos) {
-        InterceptData<AfterDrawData> interceptData = new InterceptData<>(world, drawPos, step, AfterDrawData.class);
-        this.afterDraw.apply(interceptData, this);
-    }
-
-    /**
-     * Set the interceptor to run before drawing the sphere.  The interceptor will be provided
-     * with references to the {@link ServerWorld}, the step number of the animation, the center
-     * of the sphere, and the ParticleSphere instance.
-     * <p>
-     * This implementation is used by the constructor, so subclasses cannot override this method.
-     *
-     * @param beforeDraw the new interceptor to execute prior to drawing the sphere
-     */
-    public final void setBeforeDraw(DrawInterceptor<ParticleSphere, BeforeDrawData> beforeDraw) {
-        this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
-    }
-
-    private void doBeforeDraw(ServerWorld world, int step, Vector3f drawPos) {
-        InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, drawPos, step, BeforeDrawData.class);
-        this.beforeDraw.apply(interceptData, this);
-    }
-
-    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleSphere> {
         protected float radius;
-        protected DrawInterceptor<ParticleSphere, AfterDrawData> afterDraw;
-        protected DrawInterceptor<ParticleSphere, BeforeDrawData> beforeDraw;
 
         private Builder() {}
 
@@ -135,28 +75,6 @@ public class ParticleSphere extends ParticleObject {
          */
         public B radius(float radius) {
             this.radius = radius;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleSphere#setAfterDraw(DrawInterceptor)
-         */
-        public B afterDraw(DrawInterceptor<ParticleSphere, AfterDrawData> afterDraw) {
-            this.afterDraw = afterDraw;
-            return self();
-        }
-
-        /**
-         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
-         * the value.
-         *
-         * @see ParticleSphere#setBeforeDraw(DrawInterceptor)
-         */
-        public B beforeDraw(DrawInterceptor<ParticleSphere, BeforeDrawData> beforeDraw) {
-            this.beforeDraw = beforeDraw;
             return self();
         }
 

--- a/src/test/java/net/mcbrincie/apel/lib/objects/DrawContextTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/DrawContextTest.java
@@ -1,0 +1,98 @@
+package net.mcbrincie.apel.lib.objects;
+
+import net.minecraft.particle.ParticleEffect;
+import net.minecraft.server.world.ServerWorld;
+import org.joml.Vector3f;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class DrawContextTest {
+    // Declaring a null to avoid mocking and needing the Minecraft startup
+    private static final ServerWorld NULL_WORLD = null;
+
+    @Test
+    void testAddingPrimitives() {
+        // Given a DrawContext
+        DrawContext context = new DrawContext(NULL_WORLD, new Vector3f(0), 0);
+        DrawContext.Key<Integer> key = DrawContext.integerKey("foo");
+
+        // When metadata is added, it does not throw
+        context.addMetadata(key, 3);
+
+        // Then the value is retrievable
+        int foo = context.getMetadata(key);
+        assertEquals(3, foo);
+    }
+
+    @Test
+    void testAddingWildcardGenerics() {
+        // This mimics what ParticleCombiner would do with `OBJECT_IN_USE` using a ParticleObject<?>
+        // Given a DrawContext
+        DrawContext context = new DrawContext(NULL_WORLD, new Vector3f(0), 0);
+        DrawContext.Key<ParticleObject<?>> objectInUse = DrawContext.particleObjectKey("objectInUse");
+
+        // Given a ParticlePoint
+        ParticlePoint particlePoint = new ParticlePoint((ParticleEffect) null);
+
+        // When metadata is added, it does not throw
+        context.addMetadata(objectInUse, particlePoint);
+
+        // Then the value is retrievable
+        ParticleObject<?> retrievedParticlePoint = context.getMetadata(objectInUse);
+        assertEquals(particlePoint, retrievedParticlePoint);
+    }
+
+    @Test
+    void testAddingArrays() {
+        // Given a DrawContext
+        DrawContext context = new DrawContext(NULL_WORLD, new Vector3f(0), 0);
+        DrawContext.Key<Vector3f[]> verticesKey = DrawContext.vector3fArrayKey("vertices");
+
+        // Given an array
+        Vector3f[] vertices = new Vector3f[8];
+
+        // When metadata is added, it does not throw
+        context.addMetadata(verticesKey, vertices);
+
+        // Then the value is retrievable
+        Vector3f[] retrievedVertices = context.getMetadata(verticesKey);
+        assertEquals(vertices, retrievedVertices);
+    }
+
+    @Test
+    void testMultipleKeys() {
+        // Given a DrawContext
+        DrawContext context = new DrawContext(NULL_WORLD, new Vector3f(0), 0);
+        DrawContext.Key<Integer> key = DrawContext.integerKey("foo");
+        DrawContext.Key<Integer> key2 = DrawContext.integerKey("bar");
+
+        // When metadata is added, it does not throw
+        context.addMetadata(key, 3);
+        context.addMetadata(key2, 5);
+
+        // Then the value is retrievable
+        int keyValue = context.getMetadata(key);
+        assertEquals(3, keyValue);
+        int key2Value = context.getMetadata(key2);
+        assertEquals(5, key2Value);
+    }
+
+    @Test
+    void testEquals() {
+        // Given four Keys, two of which should be equal, and two that vary on type or name
+        DrawContext.Key<Integer> key1 = DrawContext.integerKey("foo");
+        DrawContext.Key<Integer> key2 = DrawContext.integerKey("foo");
+        DrawContext.Key<Integer> keyWrongName = DrawContext.integerKey("bar");
+        DrawContext.Key<Integer> keyDifferentSource = new DrawContext.Key<>("foo") {};
+        DrawContext.Key<Boolean> keyWrongType = DrawContext.booleanKey("foo");
+
+        // Then equality works
+        assertEquals(key1, key2, "Keys of same type and name should be equal");
+        assertEquals(key1, keyDifferentSource, "Keys of same type and name, but different declarations, should be equal");
+        assertNotEquals(key1, keyWrongName, "Keys with different names should not be equal");
+        //noinspection AssertBetweenInconvertibleTypes
+        assertNotEquals(key1, keyWrongType, "Keys with different types should not be equal");
+    }
+}

--- a/src/test/java/net/mcbrincie/apel/lib/objects/DrawContextTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/DrawContextTest.java
@@ -1,6 +1,5 @@
 package net.mcbrincie.apel.lib.objects;
 
-import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ class DrawContextTest {
         DrawContext.Key<ParticleObject<?>> objectInUse = DrawContext.particleObjectKey("objectInUse");
 
         // Given a ParticlePoint
-        ParticlePoint particlePoint = new ParticlePoint((ParticleEffect) null);
+        ParticlePoint particlePoint = ParticlePoint.builder().particleEffect(null).build();
 
         // When metadata is added, it does not throw
         context.addMetadata(objectInUse, particlePoint);

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
@@ -19,7 +19,7 @@ class ParticleCombinerTest {
         ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).build();
+        ParticleCombiner combiner = ParticleCombiner.builder().object(p1).object(p2).build();
 
         // Given points to append
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
@@ -38,7 +38,7 @@ class ParticleCombinerTest {
         ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).build();
+        ParticleCombiner combiner = ParticleCombiner.builder().object(p1).object(p2).build();
 
         // Given a point to append
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
@@ -58,14 +58,14 @@ class ParticleCombinerTest {
         ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).build();
+        ParticleCombiner combiner = ParticleCombiner.builder().object(p1).object(p2).build();
 
         // Given points to append
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
         ParticlePoint p4 = NULL_POINT_BUILDER.build();
 
         // When the points are appended
-        combiner.appendObjects(p3, p4);
+        combiner.appendObjects(List.of(p3, p4));
 
         // Then the combiner has four objects
         assertEquals(4, combiner.getObjects().size());
@@ -79,7 +79,7 @@ class ParticleCombinerTest {
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).object(p3).build();
+        ParticleCombiner combiner = ParticleCombiner.builder().object(p1).object(p2).object(p3).build();
 
         // Given a rotation
         Vector3f rotation = new Vector3f(0.1f);
@@ -101,7 +101,7 @@ class ParticleCombinerTest {
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).object(p3).build();
+        ParticleCombiner combiner = ParticleCombiner.builder().object(p1).object(p2).object(p3).build();
 
         // Given a rotation
         Vector3f rotation = new Vector3f(0.1f);


### PR DESCRIPTION
We've discussed interceptors and their complexity, extensibility, and type safety a fair bit.  I think this PR lands us in a good, maintainable, explainable, flexible state.

Right now, it only modifies a few of the particle objects (those that use custom metadata) to demonstrate what is possible with metadata `Key` and values.  It doesn't quite get to the `MetadataEntry` we briefly discussed, but I think that's OK given the compile-time type safety afforded by this solution.

This approach relies on Java's reflection capabilities around understanding generics and subclasses.  Fundamentally, every `key` stored in the metadata must be a subclass of `Key<T>` that is explicitly spelled out; i.e., cannot use a generic method to define the subclass once for everyone.  This is due to Java's type erasure, which results in treating all instances of that subclass as equal, which we do not want.  Rather, we need the approach taken by C++ where every separate parameter type results it its own definition of the subclass.  This sounds verbose, but it's very succinct and easy to understand/repeat, as Java uses anonymous subclasses commonly now due to lambdas.

This PR did manage to combine one other change I think we need, which is removing the type parameter from `ParticleCombiner`, since it doesn't help clarify anything.  This is not a good practice from me to do this, so I will plan to break it into a separate change, assuming the general interceptor idea here is reasonable to implement across the rest of the `ParticleObject` subclasses.

I'll also plan to squash the commits below, since the first two were exploratory ideas that didn't really work out.