### PR TITLE
Convert to object builders

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCircle.java
@@ -3,9 +3,7 @@ package net.mcbrincie.apel.lib.objects;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
 import java.util.Optional;
@@ -20,8 +18,9 @@ import java.util.Optional;
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleCircle extends ParticleObject {
     protected float radius;
-    private DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+
+    private DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw;
 
     /** This data is used before calculations (it contains the iterated rotation) */
     public enum BeforeDrawData {}
@@ -29,43 +28,19 @@ public class ParticleCircle extends ParticleObject {
     /** This data is used after calculations (it contains the drawing position) */
     public enum AfterDrawData {}
 
-    /** Constructor for the particle circle which is a 2D shape. It accepts as parameters
-     * the particle effect to use, the radius of the circle, the rotation to apply, and the number of particles.
-     * There is also a simplified version for no rotation.
-     *
-     * <p>This implementation calls setters for amount, rotation, and radius so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param radius The radius of the circle (how big it is)
-     * @param rotation The rotation to apply
-     *
-     * @see ParticleCircle#ParticleCircle(ParticleEffect, float, int)
-    */
-    public ParticleCircle(@NotNull ParticleEffect particleEffect, float radius, Vector3f rotation, int amount) {
-        super(particleEffect, rotation);
-        this.setRadius(radius);
-        this.setAmount(amount);
+    /**
+     * Provide a builder instance.
+     * @return A builder instance
+     */
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the particle circle which is a 2D shape. It accepts as parameters
-     * the particle effect to use, the radius of the circle, & the number of particles.
-     * There is also a version that allows for rotation.
-     *
-     * <p>This implementation calls setters for amount, rotation, and radius so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param radius The radius of the circle (how big it is)
-     *
-     * @see ParticleCircle#ParticleCircle(ParticleEffect, float, Vector3f, int)
-    */
-    public ParticleCircle(@NotNull ParticleEffect particleEffect, float radius, int amount) {
-        this(particleEffect, radius, new Vector3f(0), amount);
+    private ParticleCircle(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        this.setRadius(builder.radius);
+        this.setBeforeDraw(builder.beforeDraw);
+        this.setAfterDraw(builder.afterDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -76,7 +51,6 @@ public class ParticleCircle extends ParticleObject {
     public ParticleCircle(ParticleCircle circle) {
         super(circle);
         this.radius = circle.radius;
-        this.amount = circle.amount;
         this.afterDraw = circle.afterDraw;
         this.beforeDraw = circle.beforeDraw;
     }
@@ -89,12 +63,15 @@ public class ParticleCircle extends ParticleObject {
         return radius;
     }
 
-    /** Set the radius of this ParticleCircle and returns the previous radius that was used.
+    /**
+     * Set the radius of this ParticleCircle and returns the previous radius that was used.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param radius the new radius
      * @return the previously used radius
      */
-    public float setRadius(float radius) {
+    public final float setRadius(float radius) {
         if (radius < 0) {
             throw new IllegalArgumentException("Radius cannot be negative");
         }
@@ -113,9 +90,12 @@ public class ParticleCircle extends ParticleObject {
         this.endDraw(renderer, step, drawPos);
     }
 
-    /** Set the interceptor to run after drawing the circle.  The interceptor will be provided
+    /**
+     * Set the interceptor to run after drawing the circle.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
      * position of the center of the circle.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
@@ -128,9 +108,12 @@ public class ParticleCircle extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Set the interceptor to run prior to drawing the circle.  The interceptor will be provided
+    /**
+     * Set the interceptor to run prior to drawing the circle.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
      * position of the center of the circle.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing each particle
      */
@@ -141,5 +124,48 @@ public class ParticleCircle extends ParticleObject {
     private void doBeforeDraw(ServerWorld world, int step, Vector3f pos) {
         InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, pos, step, BeforeDrawData.class);
         this.beforeDraw.apply(interceptData, this);
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected float radius;
+        protected DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set the radius on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B radius(float radius) {
+            this.radius = radius;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCircle#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleCircle, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCircle#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleCircle, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleCircle build() {
+            return new ParticleCircle(this);
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCone.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCone.java
@@ -3,7 +3,6 @@ package net.mcbrincie.apel.lib.objects;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
 import org.joml.Vector3f;
 
@@ -18,54 +17,26 @@ public class ParticleCone extends ParticleObject {
     protected float height;
     protected float radius;
 
-    private DrawInterceptor<ParticleCone, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+    private DrawInterceptor<ParticleCone, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw;
 
     public enum BeforeDrawData {}
     public enum AfterDrawData {}
 
-    /** Constructor for the particle cone which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the height of the cone, the maximum radius,
-     * the rotation to apply, and the number of particles.
-     * There is also a simplified constructor for no rotation.
-     *
-     * <p>This implementation calls setters for rotation, amount, height, and radius so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle effect to use
-     * @param height The height of the cone
-     * @param radius The radius of the cone
-     * @param rotation The rotation to apply
-     * @param amount The number of particles
-     *
-     * @see ParticleCone#ParticleCone(ParticleEffect, float, float, int)
-    */
-    public ParticleCone(ParticleEffect particleEffect, float height, float radius, Vector3f rotation, int amount) {
-        super(particleEffect, rotation);
-        this.setAmount(amount);
-        this.setHeight(height);
-        this.setRadius(radius);
+    /**
+     * Provide a builder instance.
+     * @return A builder instance
+     */
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the particle cone which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the height of the cone, the maximum radius,
-     * the rotation to apply and the number of particles.
-     * There is also a more complex version for rotation
-     *
-     * <p>This implementation calls setters for rotation, amount, height, and radius so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle effect to use
-     * @param height The height of the cone
-     * @param radius The radius of the cone
-     * @param amount The number of particles
-     *
-     * @see ParticleCone#ParticleCone(ParticleEffect, float, float, Vector3f, int)
-     */
-    public ParticleCone(ParticleEffect particleEffect, float height, float radius, int amount) {
-        this(particleEffect, height, radius, new Vector3f(), amount);
+    private ParticleCone(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        this.setHeight(builder.height);
+        this.setRadius(builder.radius);
+        this.setAfterDraw(builder.afterDraw);
+        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -162,5 +133,57 @@ public class ParticleCone extends ParticleObject {
     private void doBeforeDraw(ServerWorld world, int step) {
         InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, null, step, BeforeDrawData.class);
         this.beforeDraw.apply(interceptData, this);
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected float height;
+        protected float radius;
+        protected DrawInterceptor<ParticleCone, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set the height on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B height(float height) {
+            this.height = height;
+            return self();
+        }
+
+        /**
+         * Set the radius on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B radius(float radius) {
+            this.radius = radius;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCone#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleCone, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCone#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleCone, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleCone build() {
+            return new ParticleCone(this);
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -3,9 +3,7 @@ package net.mcbrincie.apel.lib.objects;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Quaternionf;
 import org.joml.Quaternionfc;
 import org.joml.Vector3f;
@@ -16,14 +14,18 @@ import java.util.Optional;
 /** The particle object class that represents a cuboid which is a rectangle
  * living in 3D. It is a cube if all the values of the size vector
  * are supplied with the same value.
+ * <p>
+ * <strong>Note: </strong>ParticleCuboid does not respect the {@link #getAmount()} or {@link #setAmount(int)} methods
+ * inherited from ParticleObject.  Instead, it stores amounts as described in {@link #getAmount(AreaLabel)} and
+ * {@link #setAmount(Vector3i)}.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleCuboid extends ParticleObject {
-    protected Vector3f size = new Vector3f();
-    protected Vector3i amount = new Vector3i();
+    protected Vector3f size;
+    protected Vector3i amount;
 
-    private DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+    private DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw;
 
     /** There is no data being transmitted */
     public enum AfterDrawData {}
@@ -63,88 +65,17 @@ public class ParticleCuboid extends ParticleObject {
         BOTTOM_FACE, TOP_FACE, VERTICAL_BARS, ALL_FACES
     }
 
-    /** Constructor for the particle cuboid which is a 3D rectangle. It accepts as parameters
-     * the particle effect to use, the number of particles per line in each face section (bottom is X, top is Y and
-     * the bars are Z), the size of the cuboid (width, height, depth), and the rotation to apply.
-     *
-     * <p>This implementation calls setters for rotation, size, and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param size The size in regard to width, height, depth
-     * @param rotation The rotation to apply
-     *
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, Vector3i, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, int, Vector3f, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, int, Vector3f)
-    */
-    public ParticleCuboid(ParticleEffect particleEffect, Vector3i amount, @NotNull Vector3f size, Vector3f rotation) {
-        super(particleEffect, rotation);
+    public static Builder<?> builder() {
+        return new Builder<>();
+    }
+
+    private ParticleCuboid(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, 1);
         // Defensive copies are made in setters to protect against in-place modification of vectors
-        this.setSize(size);
-        this.setAmount(amount);
-    }
-
-    /** Constructor for the particle cuboid which is a 3D rectangle. It accepts as parameters
-     * the particle effect to use, the number of particles per line in each face section (bottom is X, top is Y and
-     * the bars are Z), and the size of the cuboid (width, height, depth).
-     *
-     * <p>This implementation calls setters for rotation, size, and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param size The size in regard to width, height, depth
-     *
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, Vector3i, Vector3f, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, int, Vector3f, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, int, Vector3f)
-     */
-    public ParticleCuboid(ParticleEffect particleEffect, Vector3i amount, @NotNull Vector3f size) {
-        this(particleEffect, amount, size, new Vector3f(0));
-    }
-
-    /** Constructor for the particle cuboid which is a 3D rectangle. It accepts as parameters
-     * the particle effect to use, the number of particles per line in all face sections, the size of the cuboid
-     * (width, height, depth), and the rotation to apply.
-     *
-     * <p>This implementation calls setters for rotation, size, and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param size The size in regard to width, height, depth
-     *
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, Vector3i, Vector3f, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, Vector3i, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, int, Vector3f)
-     */
-    public ParticleCuboid(ParticleEffect particleEffect, int amount, @NotNull Vector3f size, Vector3f rotation) {
-        this(particleEffect, new Vector3i(amount), size, rotation);
-    }
-
-    /** Constructor for the particle cuboid which is a 3D rectangle. It accepts as parameters
-     * the particle effect to use, the number of particles per line in all face sections, and the size of the cuboid
-     * (width, height, depth).
-     *
-     * <p>This implementation calls setters for rotation, size, and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param size The size in regard to width, height, depth
-     *
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, Vector3i, Vector3f, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, Vector3i, Vector3f)
-     * @see ParticleCuboid#ParticleCuboid(ParticleEffect, int, Vector3f, Vector3f)
-     */
-    public ParticleCuboid(ParticleEffect particleEffect, int amount, @NotNull Vector3f size) {
-        this(particleEffect, new Vector3i(amount), size, new Vector3f(0));
+        this.setSize(builder.size);
+        this.setAmount(builder.amount);
+        this.setAfterDraw(builder.afterDraw);
+        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -165,19 +96,22 @@ public class ParticleCuboid extends ParticleObject {
         return new Vector3f(this.size);
     }
 
-    /** Sets the size of the cuboid object. The X axis corresponds to width, Y axis corresponds to height, and Z axis
+    /**
+     * Sets the size of the cuboid object. The X axis corresponds to width, Y axis corresponds to height, and Z axis
      * corresponds to depth.  All dimensions must be positive.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param size The size, a vector of positive numbers
      * @return The previous size
      *
      * @see ParticleCuboid#setSize(float)
      */
-    public Vector3f setSize(Vector3f size) {
+    public final Vector3f setSize(Vector3f size) {
         if (size.x <= 0 || size.y <= 0 || size.z <= 0) {
             throw new IllegalArgumentException("One of the size axis is below or equal to zero");
         }
-        Vector3f prevSize = new Vector3f(this.size);
+        Vector3f prevSize = this.size;
         // Defensive copy to prevent unintended modification
         this.size = new Vector3f(size);
         return prevSize;
@@ -197,18 +131,21 @@ public class ParticleCuboid extends ParticleObject {
         return this.setSize(new Vector3f(size, size, size));
     }
 
-    /** Sets the amount per area.  The X coordinate dictates the particles per line on the bottom face, the Y
+    /**
+     * Sets the amount per area.  The X coordinate dictates the particles per line on the bottom face, the Y
      * coordinate dictates the particles per line on the top face, and the Z coordinate dictates the particles per
      * vertical bar of the cuboid.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param amount The amount per area
      * @return The previous amount to use
      */
-    public Vector3i setAmount(Vector3i amount) {
+    public final Vector3i setAmount(Vector3i amount) {
         if (amount.x <= 0 || amount.y <= 0 || amount.z <= 0) {
             throw new IllegalArgumentException("One of the amount of particles axis is below or equal to 0");
         }
-        Vector3i prevAmount = new Vector3i(this.amount);
+        Vector3i prevAmount = this.amount;
         // Defensive copy to prevent unintended modification
         this.amount = new Vector3i(amount);
         return prevAmount;
@@ -297,12 +234,15 @@ public class ParticleCuboid extends ParticleObject {
         this.endDraw(renderer, step, drawPos);
     }
 
-    /** Set the interceptor to run after drawing the cuboid.  The interceptor will be provided
+    /**
+     * Set the interceptor to run after drawing the cuboid.  The interceptor will be provided
      * with references to the {@link ServerWorld} and the step number of the animation.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
-    public void setAfterDraw(DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw) {
+    public final void setAfterDraw(DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw) {
         this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
     }
 
@@ -311,13 +251,16 @@ public class ParticleCuboid extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Set the interceptor to run prior to drawing the cuboid.  The interceptor will be provided
+    /**
+     * Set the interceptor to run prior to drawing the cuboid.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
      * vertices of the cuboid.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing each particle
      */
-    public void setBeforeDraw(DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw) {
+    public final void setBeforeDraw(DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw) {
         this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
     }
 
@@ -326,5 +269,69 @@ public class ParticleCuboid extends ParticleObject {
         interceptData.addMetadata(BeforeDrawData.VERTICES, vertices);
         this.beforeDraw.apply(interceptData, this);
         return interceptData;
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected Vector3f size = new Vector3f();
+        protected Vector3i amount = new Vector3i();
+        protected DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set the size on the builder to construct a cube (all edges will have equal length).  This method is not
+         * cumulative; repeated calls to either {@code size} method will overwrite the value.
+         */
+        public B size(float size) {
+            this.size = new Vector3f(size);
+            return self();
+        }
+
+        /**
+         * Set the size on the builder.  This method is not cumulative; repeated calls to either {@code size} method
+         * will overwrite the value.
+         */
+        public B size(Vector3f size) {
+            this.size = size;
+            return self();
+        }
+
+        /**
+         * Set the amount of particles to use on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         *
+         * @see ParticleCuboid#setAmount(Vector3i)
+         */
+        public B amount(Vector3i amount) {
+            this.amount = amount;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCuboid#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleCuboid, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCuboid#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleCuboid, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleCuboid build() {
+            return new ParticleCuboid(this);
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -197,13 +197,6 @@ public class ParticleCuboid extends ParticleObject {
         return this.setSize(new Vector3f(size, size, size));
     }
 
-    /** THIS METHOD SHOULD NOT BE USED */
-    @Override
-    @Deprecated
-    public int setAmount(int amount) {
-        throw new UnsupportedOperationException("The method used is deprecated. It is not meant to be used");
-    }
-
     /** Sets the amount per area.  The X coordinate dictates the particles per line on the bottom face, the Y
      * coordinate dictates the particles per line on the top face, and the Z coordinate dictates the particles per
      * vertical bar of the cuboid.

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCylinder.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCylinder.java
@@ -3,9 +3,7 @@ package net.mcbrincie.apel.lib.objects;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
 import java.util.Optional;
@@ -23,8 +21,8 @@ public class ParticleCylinder extends ParticleObject {
     protected float radius;
     protected float height;
 
-    private DrawInterceptor<ParticleCylinder, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleCylinder, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+    private DrawInterceptor<ParticleCylinder, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleCylinder, BeforeDrawData> beforeDraw;
 
     /** This data is used before calculations (it contains the iterated rotation) */
     public enum BeforeDrawData {}
@@ -32,49 +30,16 @@ public class ParticleCylinder extends ParticleObject {
     /** This data is used after calculations (it contains the drawing position) */
     public enum AfterDrawData {}
 
-    /** Constructor for the particle cylinder. It accepts as parameters the particle effect to use, the radius of the
-     * cylinder, the height of the cylinder, the rotation to apply, and the number of particles.
-     *
-     * <p>This implementation calls setters for amount, rotation, height, and radius so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param radius The radius of the cylinder (how xz wise big it is)
-     * @param height The height of the cylinder (how tall it is)
-     * @param rotation The rotation to apply
-     *
-     * @see ParticleCylinder#ParticleCylinder(ParticleEffect, float, float, int)
-    */
-    public ParticleCylinder(
-            @NotNull ParticleEffect particleEffect, float radius, float height, Vector3f rotation, int amount
-    ) {
-        super(particleEffect, rotation);
-        this.setRadius(radius);
-        this.setAmount(amount);
-        this.setHeight(height);
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the particle cylinder. It accepts as parameters the particle effect to use, the radius of the
-     * cylinder, the height of the cylinder, and the number of particles.
-     *
-     * <p>This implementation calls setters for amount, rotation, height, and radius so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param height The height of the cylinder (how tall it is)
-     * @param radius The radius of the cylinder (how xz wise big it is)
-     *
-     * @see ParticleCylinder#ParticleCylinder(ParticleEffect, float, float, Vector3f, int)
-    */
-    public ParticleCylinder(
-            @NotNull ParticleEffect particleEffect,
-            float radius, float height, int amount
-    ) {
-        this(particleEffect, radius, height, new Vector3f(0,0,0), amount);
+    private ParticleCylinder(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        this.setRadius(builder.radius);
+        this.setHeight(builder.height);
+        this.setBeforeDraw(builder.beforeDraw);
+        this.setAfterDraw(builder.afterDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -86,7 +51,6 @@ public class ParticleCylinder extends ParticleObject {
         super(cylinder);
         this.radius = cylinder.radius;
         this.height = cylinder.height;
-        this.amount = cylinder.amount;
         this.afterDraw = cylinder.afterDraw;
         this.beforeDraw = cylinder.beforeDraw;
     }
@@ -99,13 +63,16 @@ public class ParticleCylinder extends ParticleObject {
         return radius;
     }
 
-    /** Set the radius of this ParticleCylinder and returns the previous radius that was used.  Radius must be positive.
+    /**
+     * Set the radius of this ParticleCylinder and returns the previous radius that was used.  Radius must be positive.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param radius the new radius
      * @return the previously used radius
      */
-    public float setRadius(float radius) {
-        if (radius < 0) {
+    public final float setRadius(float radius) {
+        if (radius <= 0) {
             throw new IllegalArgumentException("Radius must be positive");
         }
         float prevRadius = this.radius;
@@ -121,13 +88,16 @@ public class ParticleCylinder extends ParticleObject {
         return height;
     }
 
-    /** Sets the height of the ParticleCylinder and returns the previous height that was used.  Height must be positive.
+    /**
+     * Sets the height of the ParticleCylinder and returns the previous height that was used.  Height must be positive.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param height The new height
      * @return The previous used height
      */
-    public float setHeight(float height) {
-        if (height < 0) {
+    public final float setHeight(float height) {
+        if (height <= 0) {
             throw new IllegalArgumentException("Height must be positive");
         }
         float prevHeight = this.height;
@@ -144,13 +114,16 @@ public class ParticleCylinder extends ParticleObject {
         this.endDraw(renderer, step, drawPos);
     }
 
-    /** Set the interceptor to run after drawing the cylinder. The interceptor will be provided
+    /**
+     * Set the interceptor to run after drawing the cylinder. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
      * position where the cylinder is rendered.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
-    public void setAfterDraw(DrawInterceptor<ParticleCylinder, AfterDrawData> afterDraw) {
+    public final void setAfterDraw(DrawInterceptor<ParticleCylinder, AfterDrawData> afterDraw) {
         this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
     }
 
@@ -159,18 +132,73 @@ public class ParticleCylinder extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Set the interceptor to run prior to drawing the cylinder. The interceptor will be provided
+    /**
+     * Set the interceptor to run prior to drawing the cylinder. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
      * position where the cylinder is rendered.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing each particle
      */
-    public void setBeforeDraw(DrawInterceptor<ParticleCylinder, BeforeDrawData> beforeDraw) {
+    public final void setBeforeDraw(DrawInterceptor<ParticleCylinder, BeforeDrawData> beforeDraw) {
         this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
     }
 
     private void doBeforeDraw(ServerWorld world, int step, Vector3f pos) {
         InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, pos, step, BeforeDrawData.class);
         this.beforeDraw.apply(interceptData, this);
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected float radius;
+        protected float height;
+        protected DrawInterceptor<ParticleCylinder, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleCylinder, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set the height on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B height(float height) {
+            this.height = height;
+            return self();
+        }
+
+        /**
+         * Set the radius on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B radius(float radius) {
+            this.radius = radius;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCylinder#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleCylinder, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleCylinder#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleCylinder, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleCylinder build() {
+            return null;
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipse.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipse.java
@@ -22,8 +22,8 @@ public class ParticleEllipse extends ParticleObject {
     protected float radius;
     protected float stretch;
 
-    private DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+    private DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw;
 
     /** This data is used before calculations */
     public enum BeforeDrawData {}
@@ -31,50 +31,16 @@ public class ParticleEllipse extends ParticleObject {
     /** This data is used after calculations */
     public enum AfterDrawData {}
 
-    /** Constructor for the particle ellipse which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the radius of the ellipse, the stretch of the ellipse,
-     * the rotation to apply, and the number of particles.
-     *
-     * <p>This implementation calls setters for rotation, radius, stretch, and so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param radius The radius of the ellipse
-     * @param stretch The stretch of the ellipse
-     * @param rotation The rotation to apply
-     *
-     * @see ParticleEllipse#ParticleEllipse(ParticleEffect, float, float, int)
-     */
-    public ParticleEllipse(
-            @NotNull ParticleEffect particleEffect, float radius, float stretch, Vector3f rotation, int amount
-    ) {
-        super(particleEffect, rotation);
-        this.setRadius(radius);
-        this.setStretch(stretch);
-        this.setAmount(amount);
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the particle ellipse which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the radius of the ellipse, the stretch of the ellipse
-     * & the number of particles. There is also a version that allows for rotation.
-     *
-     * <p>This implementation calls setters for rotation, radius, stretch, and so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param radius The radius of the ellipse
-     * @param stretch The stretch of the ellipse
-     *
-     * @see ParticleEllipse#ParticleEllipse(ParticleEffect, float, float, Vector3f, int)
-     */
-    public ParticleEllipse(
-            @NotNull ParticleEffect particleEffect, float radius, float stretch, int amount
-    ) {
-        this(particleEffect, radius, stretch, new Vector3f(0,0,0), amount);
+    private ParticleEllipse(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        this.setRadius(builder.radius);
+        this.setStretch(builder.stretch);
+        this.setAfterDraw(builder.afterDraw);
+        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -86,7 +52,6 @@ public class ParticleEllipse extends ParticleObject {
         super(ellipse);
         this.radius = ellipse.radius;
         this.stretch = ellipse.stretch;
-        this.amount = ellipse.amount;
         this.beforeDraw = ellipse.beforeDraw;
         this.afterDraw = ellipse.afterDraw;
     }
@@ -99,12 +64,15 @@ public class ParticleEllipse extends ParticleObject {
         return radius;
     }
 
-    /** Set the radius of this ParticleEllipse and returns the previous radius that was used.
+    /**
+     * Set the radius of this ParticleEllipse and returns the previous radius that was used.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param radius the new radius
      * @return the previously used radius
      */
-    public float setRadius(float radius) {
+    public final float setRadius(float radius) {
         if (radius < 0) {
             throw new IllegalArgumentException("stretch cannot be negative");
         }
@@ -121,12 +89,15 @@ public class ParticleEllipse extends ParticleObject {
         return stretch;
     }
 
-    /** Sets the stretch of the ParticleEllipse and returns the previous stretch that was used.
+    /**
+     * Sets the stretch of the ParticleEllipse and returns the previous stretch that was used.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param stretch The new stretch
      * @return The previous used stretch
      */
-    public float setStretch(float stretch) {
+    public final float setStretch(float stretch) {
         if (stretch < 0) {
             throw new IllegalArgumentException("stretch cannot be negative");
         }
@@ -145,13 +116,16 @@ public class ParticleEllipse extends ParticleObject {
         this.endDraw(renderer, step, drawPos);
     }
 
-    /** Set the interceptor to run after drawing the ellipse. The interceptor will be provided
+    /**
+     * Set the interceptor to run after drawing the ellipse. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
      * position of the center of the ellipse.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
-    public void setAfterDraw(DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw) {
+    public final void setAfterDraw(DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw) {
         this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
     }
 
@@ -160,18 +134,73 @@ public class ParticleEllipse extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Set the interceptor to run prior to drawing the ellipse. The interceptor will be provided
+    /**
+     * Set the interceptor to run prior to drawing the ellipse. The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the
      * position of the center of the ellipse.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing each particle
      */
-    public void setBeforeDraw(DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw) {
+    public final void setBeforeDraw(DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw) {
         this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
     }
 
     private void doBeforeDraw(ServerWorld world, int step, Vector3f pos) {
         InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, pos, step, BeforeDrawData.class);
         this.beforeDraw.apply(interceptData, this);
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected float radius;
+        protected float stretch;
+        protected DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set the radius on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B radius(float radius) {
+            this.radius = radius;
+            return self();
+        }
+
+        /**
+         * Set the stretch on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B stretch(float stretch) {
+            this.stretch = stretch;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleEllipse#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleEllipse, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleEllipse#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleEllipse, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleEllipse build() {
+            return new ParticleEllipse(this);
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipsoid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleEllipsoid.java
@@ -5,7 +5,6 @@ import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
 import java.util.Optional;
@@ -22,8 +21,8 @@ public class ParticleEllipsoid extends ParticleObject {
     protected float ySemiAxis;
     protected float zSemiAxis;
 
-    private DrawInterceptor<ParticleEllipsoid, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleEllipsoid, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+    private DrawInterceptor<ParticleEllipsoid, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleEllipsoid, BeforeDrawData> beforeDraw;
 
     /**
      * This data is used before calculations
@@ -35,55 +34,17 @@ public class ParticleEllipsoid extends ParticleObject {
      */
     public enum AfterDrawData {}
 
-    /**
-     * Constructor for the particle ellipsoid which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the semi-axes of the ellipsoid, the number of particles,
-     * and the rotation to apply.
-     *
-     * <p>This implementation calls setters for rotation, semi-axes, and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param xSemiAxis The length of the X semi-axis
-     * @param ySemiAxis The length of the Y semi-axis
-     * @param zSemiAxis The length of the Z semi-axis
-     * @param amount The number of particles for the object
-     * @param rotation The rotation to apply
-     *
-     * @see ParticleEllipsoid#ParticleEllipsoid(ParticleEffect, float, float, float, int)
-     */
-    public ParticleEllipsoid(
-            @NotNull ParticleEffect particleEffect, float xSemiAxis, float ySemiAxis, float zSemiAxis, int amount,
-            Vector3f rotation
-    ) {
-        super(particleEffect, rotation);
-        this.setXSemiAxis(xSemiAxis);
-        this.setYSemiAxis(ySemiAxis);
-        this.setZSemiAxis(zSemiAxis);
-        this.setAmount(amount);
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
-    /**
-     * Constructor for the particle cuboid which is a 3D shape. It accepts as parameters
-     * the particle effect to use, the semi-axes of the ellipsoid, and the number of particles.
-     *
-     * <p>This implementation calls setters for rotation, semi-axes, and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param xSemiAxis The length of the X semi-axis
-     * @param ySemiAxis The length of the Y semi-axis
-     * @param zSemiAxis The length of the Z semi-axis
-     * @param amount The number of particles for the object
-     *
-     * @see ParticleEllipsoid#ParticleEllipsoid(ParticleEffect, float, float, float, int, Vector3f)
-     */
-    public ParticleEllipsoid(
-            @NotNull ParticleEffect particleEffect, float xSemiAxis, float ySemiAxis, float zSemiAxis, int amount
-    ) {
-        this(particleEffect, xSemiAxis, ySemiAxis, zSemiAxis, amount, new Vector3f(0));
+    private ParticleEllipsoid(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        this.setXSemiAxis(builder.xSemiAxis);
+        this.setYSemiAxis(builder.ySemiAxis);
+        this.setZSemiAxis(builder.zSemiAxis);
+        this.setAfterDraw(builder.afterDraw);
+        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /**
@@ -97,7 +58,6 @@ public class ParticleEllipsoid extends ParticleObject {
         this.xSemiAxis = particleEllipsoid.xSemiAxis;
         this.ySemiAxis = particleEllipsoid.ySemiAxis;
         this.zSemiAxis = particleEllipsoid.zSemiAxis;
-        this.amount = particleEllipsoid.amount;
         this.beforeDraw = particleEllipsoid.beforeDraw;
         this.afterDraw = particleEllipsoid.afterDraw;
     }
@@ -113,11 +73,13 @@ public class ParticleEllipsoid extends ParticleObject {
 
     /**
      * Sets length of the X semi-axis.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param xSemiAxis The length of the X semi-axis
      * @return The previous length of the X semi-axis
      */
-    public float setXSemiAxis(float xSemiAxis) {
+    public final float setXSemiAxis(float xSemiAxis) {
         if (xSemiAxis <= 0) {
             throw new IllegalArgumentException("Length of X semi-axis cannot be below or equal to 0");
         }
@@ -137,11 +99,13 @@ public class ParticleEllipsoid extends ParticleObject {
 
     /**
      * Sets length of the Y semi-axis.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param ySemiAxis The length of the Y semi-axis
      * @return The previous length of the Y semi-axis
      */
-    public float setYSemiAxis(float ySemiAxis) {
+    public final float setYSemiAxis(float ySemiAxis) {
         if (ySemiAxis <= 0) {
             throw new IllegalArgumentException("Length of Y semi-axis cannot be below or equal to 0");
         }
@@ -161,11 +125,13 @@ public class ParticleEllipsoid extends ParticleObject {
 
     /**
      * Sets length of the Z semi-axis.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param zSemiAxis The length of the Z semi-axis
      * @return The previous length of the Z semi-axis
      */
-    public float setZSemiAxis(float zSemiAxis) {
+    public final float setZSemiAxis(float zSemiAxis) {
         if (zSemiAxis <= 0) {
             throw new IllegalArgumentException("Length of Z semi-axis cannot be below or equal to 0");
         }
@@ -189,10 +155,12 @@ public class ParticleEllipsoid extends ParticleObject {
      * Set the interceptor to run after drawing the ellipsoid.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the center
      * of the ellipsoid.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param afterDraw the new interceptor to execute after drawing each particle
      */
-    public void setAfterDraw(DrawInterceptor<ParticleEllipsoid, AfterDrawData> afterDraw) {
+    public final void setAfterDraw(DrawInterceptor<ParticleEllipsoid, AfterDrawData> afterDraw) {
         this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
     }
 
@@ -205,15 +173,78 @@ public class ParticleEllipsoid extends ParticleObject {
      * Set the interceptor to run prior to drawing the ellipsoid.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the step number of the animation, and the center
      * of the ellipsoid.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing the ellipsoid
      */
-    public void setBeforeDraw(DrawInterceptor<ParticleEllipsoid, BeforeDrawData> beforeDraw) {
+    public final void setBeforeDraw(DrawInterceptor<ParticleEllipsoid, BeforeDrawData> beforeDraw) {
         this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
     }
 
     private void doBeforeDraw(ServerWorld world, int step, Vector3f drawPos) {
         InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, drawPos, step, BeforeDrawData.class);
         this.beforeDraw.apply(interceptData, this);
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected float xSemiAxis;
+        protected float ySemiAxis;
+        protected float zSemiAxis;
+        protected DrawInterceptor<ParticleEllipsoid, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleEllipsoid, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set the X semi-axis on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B xSemiAxis(float xSemiAxis) {
+            this.xSemiAxis = xSemiAxis;
+            return self();
+        }
+
+        /**
+         * Set the Y semi-axis on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B ySemiAxis(float ySemiAxis) {
+            this.ySemiAxis = ySemiAxis;
+            return self();
+        }
+
+        /**
+         * Set the Z semi-axis on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B zSemiAxis(float zSemiAxis) {
+            this.zSemiAxis = zSemiAxis;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleEllipsoid#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleEllipsoid, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleEllipsoid#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleEllipsoid, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleEllipsoid build() {
+            return new ParticleEllipsoid(this);
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleImage.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleImage.java
@@ -30,7 +30,7 @@ public class ParticleImage extends ParticleObject {
     private HashMap<Vector3f, ParticleEffect> positions;
 
     public ParticleImage(String filename, Vector3f rotation) {
-        super(null, rotation);
+        super(null, rotation, new Vector3f(0), 1);
         this.setFilename(filename);
     }
 
@@ -80,13 +80,6 @@ public class ParticleImage extends ParticleObject {
     public PalateGenerator getPalateGenerator() {return this.palateGenerator;}
 
     public String getFilename() {return filename;}
-
-    /** THIS METHOD SHOULD NOT BE USED */
-    @Deprecated
-    @Override
-    public ParticleEffect setParticleEffect(ParticleEffect particle) {
-        throw new UnsupportedOperationException("ParticleImage doesn't support setting a particle effect.");
-    }
 
     /** THIS METHOD SHOULD NOT BE USED */
     @Override

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
@@ -116,13 +116,6 @@ public class ParticleLine extends ParticleObject {
     }
 
     @Override
-    @Deprecated
-    public Vector3f setRotation(Vector3f rotation) {
-        // Do not throw UnsupportedOperationException in case this is called in a series of ParticleObjects
-        return null;
-    }
-
-    @Override
     public void draw(ApelServerRenderer renderer, int step, Vector3f drawPos) {
         this.doBeforeDraw(renderer.getServerWorld(), step);
 

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
@@ -17,65 +17,27 @@ import java.util.Optional;
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleTetrahedron extends ParticleObject {
-    private DrawInterceptor<ParticleTetrahedron, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleTetrahedron, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
-
-    /** There is no data being transmitted */
-    public enum BeforeDrawData {}
-    public enum AfterDrawData {}
-
     protected Vector3f vertex1;
     protected Vector3f vertex2;
     protected Vector3f vertex3;
     protected Vector3f vertex4;
 
-    private final IllegalArgumentException UNBALANCED_VERTICES = new IllegalArgumentException(
-            "Unbalanced vertices, there must be only 4 vertices"
-    );
+    private DrawInterceptor<ParticleTetrahedron, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleTetrahedron, BeforeDrawData> beforeDraw;
 
-    /** Constructor for the particle tetrahedron. It accepts as parameters
-     * the particle effect to use, the vertices that compose the tetrahedron, the number of particles, and the
-     * rotation to apply.
-     *
-     * <p>This implementation calls setters for rotation and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param vertices The vertices that make up the tetrahedron
-     * @param rotation The rotation to apply
-     *
-     * @see ParticleTetrahedron#ParticleTetrahedron(ParticleEffect, Vector3f[], int)
-    */
-    public ParticleTetrahedron(ParticleEffect particleEffect, Vector3f[] vertices, int amount, Vector3f rotation) {
-        super(particleEffect, rotation);
-        if (vertices.length != 4) {
-            throw UNBALANCED_VERTICES;
-        }
-        this.checkValidTetrahedron(vertices);
-        this.vertex1 = vertices[0];
-        this.vertex2 = vertices[1];
-        this.vertex3 = vertices[2];
-        this.vertex4 = vertices[3];
-        this.amount = amount;
+    /** There is no data being transmitted */
+    public enum BeforeDrawData {}
+    public enum AfterDrawData {}
+
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the particle tetrahedron. It accepts as parameters
-     * the particle to use, the vertices that compose the tetrahedron, and the number of particles.
-     *
-     * <p>This implementation calls setters for rotation and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param vertices The vertices that make up the tetrahedron
-     * @param amount The number of particles for the object
-     *
-     * @see ParticleTetrahedron#ParticleTetrahedron(ParticleEffect, Vector3f[], int, Vector3f)
-    */
-    public ParticleTetrahedron(ParticleEffect particleEffect, Vector3f[] vertices, int amount) {
-        this(particleEffect, vertices, amount, new Vector3f(0));
+    private ParticleTetrahedron(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        this.setVertices(builder.vertex1, builder.vertex2, builder.vertex3, builder.vertex4);
+        this.setAfterDraw(builder.afterDraw);
+        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -113,8 +75,8 @@ public class ParticleTetrahedron extends ParticleObject {
         this.checkValidTetrahedron(vertex1, vertex2, vertex3, vertex4);
     }
 
-    /** Sets the first individual vertex, it returns the previous
-     * vertex that was used. If you want to modify multiple
+    /**
+     * Sets the first individual vertex, it returns the previous vertex that was used. If you want to modify multiple
      * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
@@ -129,8 +91,8 @@ public class ParticleTetrahedron extends ParticleObject {
         return prevVertex1;
     }
 
-    /** Sets the second individual vertex, it returns the previous
-     * vertex that was used. If you want to modify multiple
+    /**
+     * Sets the second individual vertex, it returns the previous vertex that was used. If you want to modify multiple
      * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
@@ -145,8 +107,8 @@ public class ParticleTetrahedron extends ParticleObject {
         return prevVertex2;
     }
 
-    /** Sets the third individual vertex, it returns the previous
-     * vertex that was used. If you want to modify multiple
+    /**
+     * Sets the third individual vertex, it returns the previous vertex that was used. If you want to modify multiple
      * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
@@ -161,8 +123,8 @@ public class ParticleTetrahedron extends ParticleObject {
         return prevVertex3;
     }
 
-    /** Sets the third individual vertex, it returns the previous
-     * vertex that was used. If you want to modify multiple
+    /**
+     * Sets the third individual vertex, it returns the previous vertex that was used. If you want to modify multiple
      * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
@@ -177,16 +139,19 @@ public class ParticleTetrahedron extends ParticleObject {
         return prevVertex4;
     }
 
-    /** Sets all vertices at once.  If you want to set one vertex at a time,
-     * then it's recommended to use the methods {@link #setVertex1(Vector3f)}, etc.  Returns nothing.
+    /**
+     * Sets all vertices at once.  If you want to set one vertex at a time, use individual setters such as
+     * {@link #setVertex1(Vector3f)}.  Returns nothing.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param vertices The vertices to modify
      *
      * @throws IllegalArgumentException if the number of vertices supplied isn't equal to 4
     */
-    public void setVertices(Vector3f... vertices) {
+    public final void setVertices(Vector3f... vertices) {
         if (vertices.length != 4) {
-            throw UNBALANCED_VERTICES;
+            throw new IllegalArgumentException("Unbalanced vertices, there must be only 4 vertices");
         }
         this.checkValidTetrahedron(vertices);
         this.vertex1 = vertices[0];
@@ -254,13 +219,16 @@ public class ParticleTetrahedron extends ParticleObject {
         this.endDraw(renderer, step, drawPos);
     }
 
-    /** Set the interceptor to run after drawing the tetrahedron.  The interceptor will be provided
+    /**
+     * Set the interceptor to run after drawing the tetrahedron.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the position where the tetrahedron is rendered, the
      * step number of the animation, and the ParticleTetrahedron instance.  There is no other data attached.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param afterDraw the new interceptor to execute prior to drawing the tetrahedron
      */
-    public void setAfterDraw(DrawInterceptor<ParticleTetrahedron, AfterDrawData> afterDraw) {
+    public final void setAfterDraw(DrawInterceptor<ParticleTetrahedron, AfterDrawData> afterDraw) {
         this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
     }
 
@@ -269,18 +237,91 @@ public class ParticleTetrahedron extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Set the interceptor to run prior to drawing the tetrahedron.  The interceptor will be provided
+    /**
+     * Set the interceptor to run prior to drawing the tetrahedron.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the position where the tetrahedron is rendered, and the
      * step number of the animation, and the ParticleTetrahedron instance.  There is no other data attached.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing the tetrahedron
      */
-    public void setBeforeDraw(DrawInterceptor<ParticleTetrahedron, BeforeDrawData> beforeDraw) {
+    public final void setBeforeDraw(DrawInterceptor<ParticleTetrahedron, BeforeDrawData> beforeDraw) {
         this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
     }
 
     private void doBeforeDraw(ServerWorld world, int step, Vector3f pos) {
         InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, pos, step, BeforeDrawData.class);
         this.beforeDraw.apply(interceptData, this);
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected Vector3f vertex1;
+        protected Vector3f vertex2;
+        protected Vector3f vertex3;
+        protected Vector3f vertex4;
+        protected DrawInterceptor<ParticleTetrahedron, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleTetrahedron, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set vertex1 on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B vertex1(Vector3f vertex1) {
+            this.vertex1 = vertex1;
+            return self();
+        }
+
+        /**
+         * Set vertex2 on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B vertex2(Vector3f vertex2) {
+            this.vertex2 = vertex2;
+            return self();
+        }
+
+        /**
+         * Set vertex3 on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B vertex3(Vector3f vertex3) {
+            this.vertex3 = vertex3;
+            return self();
+        }
+
+        /**
+         * Set vertex4 on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B vertex4(Vector3f vertex4) {
+            this.vertex4 = vertex4;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleTetrahedron#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleTetrahedron, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleTetrahedron#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleTetrahedron, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleTetrahedron build() {
+            return new ParticleTetrahedron(this);
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
@@ -3,7 +3,6 @@ package net.mcbrincie.apel.lib.objects;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
-import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
 import org.joml.Quaternionf;
 import org.joml.Quaternionfc;
@@ -17,63 +16,30 @@ import java.util.Optional;
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleTriangle extends ParticleObject {
-    private DrawInterceptor<ParticleTriangle, AfterDrawData> afterDraw = DrawInterceptor.identity();
-    private DrawInterceptor<ParticleTriangle, BeforeDrawData> beforeDraw = DrawInterceptor.identity();
+    protected Vector3f vertex1;
+    protected Vector3f vertex2;
+    protected Vector3f vertex3;
+
+    private DrawInterceptor<ParticleTriangle, AfterDrawData> afterDraw;
+    private DrawInterceptor<ParticleTriangle, BeforeDrawData> beforeDraw;
 
     /** There is no data being transmitted */
     public enum BeforeDrawData {}
     public enum AfterDrawData {}
 
-    protected Vector3f vertex1;
-    protected Vector3f vertex2;
-    protected Vector3f vertex3;
-
     private final IllegalArgumentException UNBALANCED_VERTICES = new IllegalArgumentException(
             "Unbalanced vertices, there must be only 3 vertices"
     );
 
-    /** Constructor for the particle triangle. It accepts as parameters
-     * the particle effect to use, the vertices that compose the triangle, the number of particles, and the
-     * rotation to apply.
-     *
-     * <p>This implementation calls setters for rotation and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param amount The number of particles for the object
-     * @param vertices The vertices that make up the triangle
-     * @param rotation The rotation to apply
-     *
-     * @see ParticleTriangle#ParticleTriangle(ParticleEffect, Vector3f[], int)
-    */
-    public ParticleTriangle(ParticleEffect particleEffect, Vector3f[] vertices, int amount, Vector3f rotation) {
-        super(particleEffect, rotation);
-        if (vertices.length != 3) {
-            throw UNBALANCED_VERTICES;
-        }
-        this.checkValidTriangle(vertices);
-        this.vertex1 = vertices[0];
-        this.vertex2 = vertices[1];
-        this.vertex3 = vertices[2];
-        this.setAmount(amount);
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the particle triangle. It accepts as parameters
-     * the particle to use, the vertices that compose the triangle, and the number of particles.
-     *
-     * <p>This implementation calls setters for rotation and amount so checks are performed to
-     * ensure valid values are accepted for each property.  Subclasses should take care not to violate these lest
-     * they risk undefined behavior.
-     *
-     * @param particleEffect The particle to use
-     * @param vertices The vertices that make up the triangle
-     * @param amount The number of particles for the object
-     *
-     * @see ParticleTriangle#ParticleTriangle(ParticleEffect, Vector3f[], int, Vector3f)
-    */
-    public ParticleTriangle(ParticleEffect particleEffect, Vector3f[] vertices, int amount) {
-        this(particleEffect, vertices, amount, new Vector3f(0));
+    private ParticleTriangle(Builder<?> builder) {
+        super(builder.particleEffect, builder.rotation, builder.offset, builder.amount);
+        this.setVertices(builder.vertex1, builder.vertex2, builder.vertex3);
+        this.setAfterDraw(builder.afterDraw);
+        this.setBeforeDraw(builder.beforeDraw);
     }
 
     /** The copy constructor for a specific particle object. It copies all
@@ -105,8 +71,8 @@ public class ParticleTriangle extends ParticleObject {
         this.checkValidTriangle(vertex1, vertex2, vertex3);
     }
 
-    /** Sets the first individual vertex, it returns the previous
-     * vertex that was used. If you want to modify multiple
+    /**
+     * Sets the first individual vertex, it returns the previous vertex that was used. If you want to modify multiple
      * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
@@ -121,8 +87,8 @@ public class ParticleTriangle extends ParticleObject {
         return prevVertex1;
     }
 
-    /** Sets the second individual vertex, it returns the previous
-     * vertex that was used. If you want to modify multiple
+    /**
+     * Sets the second individual vertex, it returns the previous vertex that was used. If you want to modify multiple
      * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
@@ -137,8 +103,8 @@ public class ParticleTriangle extends ParticleObject {
         return prevVertex2;
     }
 
-    /** Sets the third individual vertex, it returns the previous
-     * vertex that was used. If you want to modify multiple
+    /**
+     * Sets the third individual vertex, it returns the previous vertex that was used. If you want to modify multiple
      * vertices at once then use {@code setVertices}.
      *
      * @param newVertex The new vertex
@@ -153,14 +119,17 @@ public class ParticleTriangle extends ParticleObject {
         return prevVertex3;
     }
 
-    /** Sets all vertices at once.  If you want to set one vertex at a time, then it's recommended to use
-     * {@link #setVertex1(Vector3f)}, etc.  Returns nothing.
+    /**
+     * Sets all vertices at once.  If you want to set one vertex at a time, use individual setters such as
+     * {@link #setVertex1(Vector3f)}.  Returns nothing.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param vertices The vertices to modify
      *
      * @throws IllegalArgumentException if the number of vertices supplied isn't equal to 3
     */
-    public void setVertices(Vector3f... vertices) {
+    public final void setVertices(Vector3f... vertices) {
         if (vertices.length != 3) {
             throw UNBALANCED_VERTICES;
         }
@@ -217,13 +186,16 @@ public class ParticleTriangle extends ParticleObject {
         this.endDraw(renderer, step, drawPos);
     }
 
-    /** Set the interceptor to run after drawing the triangle.  The interceptor will be provided
+    /**
+     * Set the interceptor to run after drawing the triangle.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the position where the triangle is rendered, the
      * step number of the animation, and the ParticleTriangle instance.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param afterDraw the new interceptor to execute prior to drawing the triangle
      */
-    public void setAfterDraw(DrawInterceptor<ParticleTriangle, AfterDrawData> afterDraw) {
+    public final void setAfterDraw(DrawInterceptor<ParticleTriangle, AfterDrawData> afterDraw) {
         this.afterDraw = Optional.ofNullable(afterDraw).orElse(DrawInterceptor.identity());
     }
 
@@ -232,18 +204,82 @@ public class ParticleTriangle extends ParticleObject {
         this.afterDraw.apply(interceptData, this);
     }
 
-    /** Set the interceptor to run prior to drawing the triangle.  The interceptor will be provided
+    /**
+     * Set the interceptor to run prior to drawing the triangle.  The interceptor will be provided
      * with references to the {@link ServerWorld}, the position where the triangle is rendered, the
      * step number of the animation, and the ParticleTriangle instance.
+     * <p>
+     * This implementation is used by the constructor, so subclasses cannot override this method.
      *
      * @param beforeDraw the new interceptor to execute prior to drawing the triangle
      */
-    public void setBeforeDraw(DrawInterceptor<ParticleTriangle, BeforeDrawData> beforeDraw) {
+    public final void setBeforeDraw(DrawInterceptor<ParticleTriangle, BeforeDrawData> beforeDraw) {
         this.beforeDraw = Optional.ofNullable(beforeDraw).orElse(DrawInterceptor.identity());
     }
 
     private void doBeforeDraw(ServerWorld world, int step, Vector3f pos) {
         InterceptData<BeforeDrawData> interceptData = new InterceptData<>(world, pos, step, BeforeDrawData.class);
         this.beforeDraw.apply(interceptData, this);
+    }
+
+    public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B> {
+        protected Vector3f vertex1;
+        protected Vector3f vertex2;
+        protected Vector3f vertex3;
+        protected DrawInterceptor<ParticleTriangle, AfterDrawData> afterDraw;
+        protected DrawInterceptor<ParticleTriangle, BeforeDrawData> beforeDraw;
+
+        private Builder() {}
+
+        /**
+         * Set vertex1 on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B vertex1(Vector3f vertex1) {
+            this.vertex1 = vertex1;
+            return self();
+        }
+
+        /**
+         * Set vertex2 on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B vertex2(Vector3f vertex2) {
+            this.vertex2 = vertex2;
+            return self();
+        }
+
+        /**
+         * Set vertex3 on the builder.  This method is not cumulative; repeated calls will overwrite the value.
+         */
+        public B vertex3(Vector3f vertex3) {
+            this.vertex3 = vertex3;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run after drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleTriangle#setAfterDraw(DrawInterceptor)
+         */
+        public B afterDraw(DrawInterceptor<ParticleTriangle, AfterDrawData> afterDraw) {
+            this.afterDraw = afterDraw;
+            return self();
+        }
+
+        /**
+         * Sets the interceptor to run before drawing.  This method is not cumulative; repeated calls will overwrite
+         * the value.
+         *
+         * @see ParticleTriangle#setBeforeDraw(DrawInterceptor)
+         */
+        public B beforeDraw(DrawInterceptor<ParticleTriangle, BeforeDrawData> beforeDraw) {
+            this.beforeDraw = beforeDraw;
+            return self();
+        }
+
+        @Override
+        public ParticleTriangle build() {
+            return new ParticleTriangle(this);
+        }
     }
 }

--- a/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
@@ -1,15 +1,14 @@
 package net.mcbrincie.apel.lib.animators;
 
 import net.mcbrincie.apel.lib.objects.ParticlePoint;
-import net.minecraft.particle.ParticleEffect;
 import org.joml.Vector3f;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LinearAnimatorTest {
     // null particle to avoid needing to load Minecraft
-    private static final ParticlePoint POINT_WITH_NULL_PARTICLE = new ParticlePoint((ParticleEffect) null);
+    private static final ParticlePoint POINT_WITH_NULL_PARTICLE = ParticlePoint.builder().particleEffect(null).build();
 
     @Test
     void testGetDistance() {

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
@@ -1,29 +1,27 @@
 package net.mcbrincie.apel.lib.objects;
 
-import net.minecraft.particle.ParticleEffect;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
 class ParticleCombinerTest {
     // Use this to prevent having to initialize all the Minecraft Server logic
-    private static final ParticleEffect NULL_PARTICLE = null;
+    private static final ParticlePoint.Builder<?> NULL_POINT_BUILDER = ParticlePoint.builder().particleEffect(null);
 
     @Test
     void setObjectsViaList() {
         // Given a couple ParticlePoints
-        ParticlePoint p1 = new ParticlePoint(NULL_PARTICLE);
-        ParticlePoint p2 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p1 = NULL_POINT_BUILDER.build();
+        ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
         ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
 
         // Given points to append
-        ParticlePoint p3 = new ParticlePoint(NULL_PARTICLE);
-        ParticlePoint p4 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p3 = NULL_POINT_BUILDER.build();
+        ParticlePoint p4 = NULL_POINT_BUILDER.build();
 
         // When the points are set
         combiner.setObjects(List.of(p3, p4));
@@ -34,14 +32,14 @@ class ParticleCombinerTest {
     @Test
     void setObjectsLeavesAppendFunctional() {
         // Given a couple ParticlePoints
-        ParticlePoint p1 = new ParticlePoint(NULL_PARTICLE);
-        ParticlePoint p2 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p1 = NULL_POINT_BUILDER.build();
+        ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
         ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
 
         // Given a point to append
-        ParticlePoint p3 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p3 = NULL_POINT_BUILDER.build();
 
         // When the points are set
         combiner.setObjects(List.of(p1, p2));
@@ -54,15 +52,15 @@ class ParticleCombinerTest {
     @Test
     void appendObjects() {
         // Given a couple ParticlePoints
-        ParticlePoint p1 = new ParticlePoint(NULL_PARTICLE);
-        ParticlePoint p2 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p1 = NULL_POINT_BUILDER.build();
+        ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
         ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
 
         // Given points to append
-        ParticlePoint p3 = new ParticlePoint(NULL_PARTICLE);
-        ParticlePoint p4 = new ParticlePoint(NULL_PARTICLE);
+        ParticlePoint p3 = NULL_POINT_BUILDER.build();
+        ParticlePoint p4 = NULL_POINT_BUILDER.build();
 
         // When the points are appended
         combiner.appendObjects(p3, p4);

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCombinerTest.java
@@ -1,5 +1,6 @@
 package net.mcbrincie.apel.lib.objects;
 
+import org.joml.Vector3f;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ParticleCombinerTest {
     // Use this to prevent having to initialize all the Minecraft Server logic
     private static final ParticlePoint.Builder<?> NULL_POINT_BUILDER = ParticlePoint.builder().particleEffect(null);
+    private static final float EPSILON = 1e-3f;
 
     @Test
     void setObjectsViaList() {
@@ -17,7 +19,7 @@ class ParticleCombinerTest {
         ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
+        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).build();
 
         // Given points to append
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
@@ -36,7 +38,7 @@ class ParticleCombinerTest {
         ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
+        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).build();
 
         // Given a point to append
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
@@ -56,7 +58,7 @@ class ParticleCombinerTest {
         ParticlePoint p2 = NULL_POINT_BUILDER.build();
 
         // Given a ParticleCombiner
-        ParticleCombiner<ParticlePoint> combiner = new ParticleCombiner<>(p1, p2);
+        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).build();
 
         // Given points to append
         ParticlePoint p3 = NULL_POINT_BUILDER.build();
@@ -67,5 +69,53 @@ class ParticleCombinerTest {
 
         // Then the combiner has four objects
         assertEquals(4, combiner.getObjects().size());
+    }
+
+    @Test
+    void testSetRotations() {
+        // Given a couple ParticlePoints
+        ParticlePoint p1 = NULL_POINT_BUILDER.build();
+        ParticlePoint p2 = NULL_POINT_BUILDER.build();
+        ParticlePoint p3 = NULL_POINT_BUILDER.build();
+
+        // Given a ParticleCombiner
+        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).object(p3).build();
+
+        // Given a rotation
+        Vector3f rotation = new Vector3f(0.1f);
+
+        // When the children's rotation is set
+        combiner.setRotations(rotation);
+
+        // Then each child object has the same rotation
+        assertEquals(rotation, combiner.getObject(0).getRotation());
+        assertEquals(rotation, combiner.getObject(1).getRotation());
+        assertEquals(rotation, combiner.getObject(2).getRotation());
+    }
+
+    @Test
+    void testSetRotationsWithOffset() {
+        // Given a couple ParticlePoints
+        ParticlePoint p1 = NULL_POINT_BUILDER.build();
+        ParticlePoint p2 = NULL_POINT_BUILDER.build();
+        ParticlePoint p3 = NULL_POINT_BUILDER.build();
+
+        // Given a ParticleCombiner
+        ParticleCombiner<ParticleObject> combiner = ParticleCombiner.builder().object(p1).object(p2).object(p3).build();
+
+        // Given a rotation
+        Vector3f rotation = new Vector3f(0.1f);
+
+        // When the children's rotation is set, with varying rotations per axis (to verify independence)
+        combiner.setRotations(rotation, 0.1f, 0.2f, 0.3f);
+
+        // Then each child object has the same rotation
+        assertVector3fEquals(rotation, combiner.getObject(0).getRotation());
+        assertVector3fEquals(new Vector3f(0.2f, 0.3f, 0.4f), combiner.getObject(1).getRotation());
+        assertVector3fEquals(new Vector3f(0.3f, 0.5f, 0.7f), combiner.getObject(2).getRotation());
+    }
+
+    private static void assertVector3fEquals(Vector3f expected, Vector3f actual) {
+        assertTrue(expected.equals(actual, EPSILON));
     }
 }


### PR DESCRIPTION
This provides the builder pattern for all `ParticleObjects` except `ParticleImage`.  Circle and Cone were done as a preview for fully handling #35.  The constructors become private, and the only method by which objects can be created is the static `builder()` method.

This does move to use setters everywhere when setting properties from within a constructor so we get the same validity checks in both constructors and changes from interceptors.  That requires the setters called from constructors (and any further methods they call) that are `public` or `protected` to be made `final` so they cannot be overridden in a subclass and called before the subclass initializes.

Examples from the `DebugParticleWand`:
```java
private ParticleCone getParticleCone() {
    DrawInterceptor<ParticleCone, ParticleCone.BeforeDrawData> beforeDraw = (data, obj) -> {
        obj.setRotation(obj.getRotation().add(0.01f, 0, 0));
        obj.setOffset(obj.getOffset().add(0, 0, 0.05f));
    };
    return ParticleCone.builder().particleEffect(ParticleTypes.CRIT).height(6f).radius(3f).amount(200)
                       .offset(new Vector3f(0, 10, 0)).beforeDraw(beforeDraw).build();
}

private @NotNull ParticleCircle getParticleCircle() {
    DrawInterceptor<ParticleCircle, ParticleCircle.BeforeDrawData> beforeDraw = (data, obj) -> obj.setOffset(
            new Vector3f(0, data.getCurrentStep() % 20 / 20f, (float) data.getCurrentStep() / 100));
    return ParticleCircle.builder().particleEffect(ParticleTypes.SOUL_FIRE_FLAME).radius(3f).amount(50)
                         .beforeDraw(beforeDraw).build();
}
```

Like the other one, let me know how this looks, and I can finish the conversion across all ParticleObjects.  I do think it would make sense to do #30 before this one, so the `beforeDraw` and `afterDraw` interceptors move into the `ParticleObject.Builder` instead of being replicated about 16 times in our objects and require users to put them in their own `Builder` implementations.

This will also need a "How To: Create a new ParticleObject subclass" that explains the way these builders work so others can align with them.  Ultimately, though, since they're owning their subclasses, Apel cannot control their precise implementations.