### PR TITLE
Use the new vertex to validate tetrahedron

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
@@ -123,8 +123,8 @@ public class ParticleTetrahedron extends ParticleObject {
      * @see ParticleTetrahedron#setVertices(Vector3f...)
      */
     public Vector3f setVertex1(Vector3f newVertex) {
+        this.checkValidTetrahedron(newVertex, this.vertex2, this.vertex3, this.vertex4);
         Vector3f prevVertex1 = this.vertex1;
-        this.checkValidTetrahedron(vertex1, this.vertex2, this.vertex3, this.vertex4);
         this.vertex1 = newVertex;
         return prevVertex1;
     }
@@ -139,8 +139,8 @@ public class ParticleTetrahedron extends ParticleObject {
      * @see ParticleTetrahedron#setVertices(Vector3f...)
      */
     public Vector3f setVertex2(Vector3f newVertex) {
+        this.checkValidTetrahedron(this.vertex1, newVertex, this.vertex3, this.vertex4);
         Vector3f prevVertex2 = this.vertex2;
-        this.checkValidTetrahedron(this.vertex1, vertex2, this.vertex3, this.vertex4);
         this.vertex2 = newVertex;
         return prevVertex2;
     }
@@ -155,8 +155,8 @@ public class ParticleTetrahedron extends ParticleObject {
      * @see ParticleTetrahedron#setVertices(Vector3f...)
      */
     public Vector3f setVertex3(Vector3f newVertex) {
+        this.checkValidTetrahedron(this.vertex1, this.vertex2, newVertex, this.vertex4);
         Vector3f prevVertex3 = this.vertex3;
-        this.checkValidTetrahedron(this.vertex1, this.vertex2, vertex3, this.vertex4);
         this.vertex3 = newVertex;
         return prevVertex3;
     }
@@ -171,8 +171,8 @@ public class ParticleTetrahedron extends ParticleObject {
      * @see ParticleTetrahedron#setVertices(Vector3f...)
     */
     public Vector3f setVertex4(Vector3f newVertex) {
+        this.checkValidTetrahedron(this.vertex1, this.vertex2, this.vertex3, newVertex);
         Vector3f prevVertex4 = this.vertex4;
-        this.checkValidTetrahedron(this.vertex1, this.vertex2, this.vertex3, vertex4);
         this.vertex4 = newVertex;
         return prevVertex4;
     }


### PR DESCRIPTION
Fixes #40

The validation used to use the four vertices already existing within the instance, not the new vertex provided.  Therefore, start using the new vertex and perform the check prior to anything else.  There's no reason to set a local variable if an exception will be thrown.

Note that the invariant of a valid tetrahedron is easily broken because `getVertex1()` and others return a reference to a Vector3f that may be modified in-place, and there's no way to detect or raise an exception if that happens unless the getters return copies and the setters make defensive copies.  The tradeoff is performance, especially on per-frame interceptors, if both the getter and setter are making copies.  The alternative is to ditch the check altogether and just let users render the lines that fully connect the four vertices.