### PR TITLE
Use the new vertex to validate triangles

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
@@ -115,8 +115,8 @@ public class ParticleTriangle extends ParticleObject {
      * @see ParticleTriangle#setVertices(Vector3f...)
      */
     public Vector3f setVertex1(Vector3f newVertex) {
+        this.checkValidTriangle(newVertex, this.vertex2, this.vertex3);
         Vector3f prevVertex1 = this.vertex1;
-        this.checkValidTriangle(vertex1, this.vertex2, this.vertex3);
         this.vertex1 = newVertex;
         return prevVertex1;
     }
@@ -131,8 +131,8 @@ public class ParticleTriangle extends ParticleObject {
      * @see ParticleTriangle#setVertices(Vector3f...)
      */
     public Vector3f setVertex2(Vector3f newVertex) {
+        this.checkValidTriangle(this.vertex1, newVertex, this.vertex3);
         Vector3f prevVertex2 = this.vertex2;
-        this.checkValidTriangle(this.vertex1, vertex2, this.vertex3);
         this.vertex2 = newVertex;
         return prevVertex2;
     }
@@ -147,8 +147,8 @@ public class ParticleTriangle extends ParticleObject {
      * @see ParticleTriangle#setVertices(Vector3f...)
      */
     public Vector3f setVertex3(Vector3f newVertex) {
+        this.checkValidTriangle(this.vertex1, this.vertex2, newVertex);
         Vector3f prevVertex3 = this.vertex3;
-        this.checkValidTriangle(this.vertex1, this.vertex2, vertex3);
         this.vertex3 = newVertex;
         return prevVertex3;
     }


### PR DESCRIPTION
Fixes #41 

The validation used to use the three vertices already existing within the instance, not the new vertex provided.  Therefore, start using the new vertex and perform the check prior to anything else.  There's no reason to set a local variable if an exception will be thrown.

Note that the invariant of a valid triangle is easily broken because `getVertex1()` and others return a reference to a `Vector3f` that may be modified in-place, and there's no way to detect or raise an exception if that happens unless the getters return copies and the setters make defensive copies.  The tradeoff is performance, especially on per-frame interceptors, if both the getter and setter are making copies.  The alternative is to ditch the check altogether and just let users render the lines that fully connect the three vertices.