### PR TITLE
Allow `#amount(int)` in ParticleCuboid.Builder

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -17,7 +17,8 @@ import java.util.Optional;
  * <p>
  * <strong>Note: </strong>ParticleCuboid does not respect the {@link #getAmount()} or {@link #setAmount(int)} methods
  * inherited from ParticleObject.  Instead, it stores amounts as described in {@link #getAmount(AreaLabel)} and
- * {@link #setAmount(Vector3i)}.
+ * {@link #setAmount(Vector3i)}.  This also means that the builder method {@link ParticleObject.Builder#amount(int)} is
+ * not ideal to use, though it will propagate an integer {@code i} into the vector {@code (i, i, i)}.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleCuboid extends ParticleObject {
@@ -331,6 +332,10 @@ public class ParticleCuboid extends ParticleObject {
 
         @Override
         public ParticleCuboid build() {
+            // Handle the amount being set via integer instead of Vector3i
+            if (this.amount.equals(new Vector3i()) && super.amount > 0) {
+                this.amount(new Vector3i(super.amount));
+            }
             return new ParticleCuboid(this);
         }
     }

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCuboidTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCuboidTest.java
@@ -1,0 +1,23 @@
+package net.mcbrincie.apel.lib.objects;
+
+import org.joml.Vector3i;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParticleCuboidTest {
+
+    @Test
+    void builderAmountAsIntegerWorks() {
+        // Given a minimally configured ParticleCuboid Builder and particle amount
+        int amount = 10;
+        ParticleCuboid.Builder<?> builder = ParticleCuboid.builder().size(1f).amount(amount);
+
+        // When built
+        ParticleCuboid cuboid = builder.build();
+
+        // Then the amount is a vector with components equal to the integer
+        assertEquals(new Vector3i(amount), cuboid.getAmount(ParticleCuboid.AreaLabel.ALL_FACES));
+    }
+
+}


### PR DESCRIPTION
Fixes #46

Cuboid no longer has a constructor with special handling for `amount`, and it can't easily be made clear on the builders that `#amount(int)` isn't intended for cuboid configuration.  Therefore, take advantage of the builder's ability to perform logic before construction and see if the user set an integer amount.  If so, convert to `Vector3i` as used by Cuboid.

Updates documentation to encourage the use of the `Vector3i` approach.

Other options:
- Throw IllegalStateException if amount isn't set via the `Vector3i` overload.  This is a reasonable choice.
- Remove `final` to allow overload in the Cuboid builder.  This is possible, but is poor inheritance design, as ParticleObject must maintain its own invariants.
- Create a record class to encapsulate Cuboid amounts.  This is a good long-term solution because the current breakdown across `Vector3i` is not intuitive.