### PR TITLE
Render all frames when `processSpeed > 1`

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -268,19 +268,17 @@ public abstract class PathAnimatorBase {
             Apel.DRAW_EXECUTOR.submit(func);
             return;
         }
-        if (this.processingSpeed <= 1) {
-            Apel.SCHEDULER.allocateNewStep(
-                    this, new ScheduledStep(this.delay, new Runnable[]{func})
-            );
-            return;
-        } else if (step % this.processingSpeed != 0) {
-            this.storedFuncsBuffer.add(func);
+        if (this.processingSpeed == 1) {
+            Apel.SCHEDULER.allocateNewStep(this, new ScheduledStep(this.delay, new Runnable[]{func}));
             return;
         }
-        Apel.SCHEDULER.allocateNewStep(
-                this, new ScheduledStep(this.delay, this.storedFuncsBuffer.toArray(Runnable[]::new))
-        );
-        this.storedFuncsBuffer.clear();
+        this.storedFuncsBuffer.add(func);
+        if (this.storedFuncsBuffer.size() == this.processingSpeed) {
+            Apel.SCHEDULER.allocateNewStep(
+                    this, new ScheduledStep(this.delay, this.storedFuncsBuffer.toArray(Runnable[]::new))
+            );
+            this.storedFuncsBuffer.clear();
+        }
     }
 
     /**


### PR DESCRIPTION
When `processSpeed` > 1, one out of N frames is dropped.  This changes it to render all frames, thus letting the animator interceptor truly determine whether a frame should be rendered or not.

I do think this will change again if the proposal to have animators tick is selected, but in the interim, this is a good fix to apply.