### PR TITLE
Animators cleanup in prep for builders

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
@@ -237,8 +237,10 @@ public class BezierCurveAnimator extends PathAnimatorBase {
                 Vector3f pos = bezierCurve.compute(t);
                 InterceptData<OnRenderStep> interceptData =
                         this.doBeforeStep(renderer.getServerWorld(), pos, step);
-                if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
-                pos = (Vector3f) interceptData.getMetadata(OnRenderStep.RENDERING_POSITION);
+                if (!interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP, true)) {
+                    continue;
+                }
+                pos = interceptData.getMetadata(OnRenderStep.RENDERING_POSITION, pos);
                 this.handleDrawingStep(renderer, step, pos);
             }
         }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
@@ -183,7 +183,7 @@ public class BezierCurveAnimator extends PathAnimatorBase {
     public float getDistance() {
         float sumDistance = 0;
         for (BezierCurve bezierCurve : this.bezierCurves) {
-            sumDistance += bezierCurve.length(this.convertToSteps());
+            sumDistance += bezierCurve.length(this.convertIntervalToSteps());
         }
         return sumDistance;
     }
@@ -196,7 +196,7 @@ public class BezierCurveAnimator extends PathAnimatorBase {
     public AnimationTrimming<Integer> setTrimming(AnimationTrimming<Integer> trimming) {
         int startStep = trimming.getStart();
         int endStep = trimming.getEnd();
-        if (startStep <= 0 || endStep >= this.getRenderSteps() || startStep >= endStep) {
+        if (startStep <= 0 || endStep >= this.getRenderingSteps() || startStep >= endStep) {
             throw new IllegalArgumentException("Invalid animation trimming range");
         }
         AnimationTrimming<Integer> prevTrimming = this.trimming;
@@ -213,7 +213,7 @@ public class BezierCurveAnimator extends PathAnimatorBase {
     }
 
     @Override
-    public int convertToSteps() {
+    public int convertIntervalToSteps() {
         int steps = 0;
         for (int i = 0; i < this.bezierCurves.length; i++) {
             int curveSteps = getCurveSteps(this.bezierCurves[i], this.renderingInterval[i]);

--- a/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
@@ -27,9 +27,9 @@ public class BezierCurveAnimator extends PathAnimatorBase {
     protected float[] renderingInterval;
     protected AnimationTrimming<Integer> trimming = new AnimationTrimming<>(0, -1);
 
-    protected DrawInterceptor<BezierCurveAnimator, onRenderingStep> duringRenderingSteps = DrawInterceptor.identity();
+    protected DrawInterceptor<BezierCurveAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
-    public enum onRenderingStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
+    public enum OnRenderStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
     /**
      * Constructor for the bézier animation. This constructor is
      * meant to be used in the case that you want a good consistent
@@ -255,10 +255,10 @@ public class BezierCurveAnimator extends PathAnimatorBase {
             for (float t = 0; t < 1.0f; t += tStep) {
                 step++;
                 Vector3f pos = bezierCurve.compute(t);
-                InterceptData<onRenderingStep> interceptData =
+                InterceptData<OnRenderStep> interceptData =
                         this.doBeforeStep(renderer.getServerWorld(), pos, step);
-                if (!((boolean) interceptData.getMetadata(onRenderingStep.SHOULD_DRAW_STEP))) continue;
-                pos = (Vector3f) interceptData.getMetadata(onRenderingStep.RENDERING_POSITION);
+                if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
+                pos = (Vector3f) interceptData.getMetadata(OnRenderStep.RENDERING_POSITION);
                 this.handleDrawingStep(renderer, step, pos);
             }
         }
@@ -271,18 +271,18 @@ public class BezierCurveAnimator extends PathAnimatorBase {
      *
      * @param duringRenderingSteps the new interceptor to execute before drawing the individual steps
      */
-    public void setDuringRenderingSteps(DrawInterceptor<BezierCurveAnimator, onRenderingStep> duringRenderingSteps) {
+    public void setDuringRenderingSteps(DrawInterceptor<BezierCurveAnimator, OnRenderStep> duringRenderingSteps) {
         this.duringRenderingSteps = Optional.ofNullable(duringRenderingSteps).orElse(DrawInterceptor.identity());
     }
 
-    protected InterceptData<onRenderingStep> doBeforeStep(
+    protected InterceptData<OnRenderStep> doBeforeStep(
             ServerWorld world, Vector3f position, int currStep
     ) {
-        InterceptData<onRenderingStep> interceptData = new InterceptData<>(
-                world, null, currStep, onRenderingStep.class
+        InterceptData<OnRenderStep> interceptData = new InterceptData<>(
+                world, null, currStep, OnRenderStep.class
         );
-        interceptData.addMetadata(onRenderingStep.RENDERING_POSITION, position);
-        interceptData.addMetadata(onRenderingStep.SHOULD_DRAW_STEP, true);
+        interceptData.addMetadata(OnRenderStep.RENDERING_POSITION, position);
+        interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
@@ -43,7 +43,8 @@ public class BezierCurveAnimator extends PathAnimatorBase {
      * @param renderingInterval The number of blocks before placing a new render step
      */
     public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve curve, @NotNull ParticleObject particle, float renderingInterval
+            int delay, @NotNull BezierCurve curve, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
+            float renderingInterval
     ) {
         this(delay, new BezierCurve[]{curve}, particle, new float[]{renderingInterval});
     }
@@ -58,7 +59,8 @@ public class BezierCurveAnimator extends PathAnimatorBase {
      * @param renderingSteps The amount of rendering steps for the animation
      */
     public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve curve, @NotNull ParticleObject particle, int renderingSteps
+            int delay, @NotNull BezierCurve curve, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
+            int renderingSteps
     ) {
         this(delay, new BezierCurve[]{curve}, particle, new int[]{renderingSteps});
     }
@@ -77,7 +79,8 @@ public class BezierCurveAnimator extends PathAnimatorBase {
      * @param renderingInterval The number of blocks before placing a new render step
      */
     public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves, @NotNull ParticleObject particle, float renderingInterval
+            int delay, @NotNull BezierCurve[] bezierCurves,
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval
     ) {
         this(delay, bezierCurves, particle, defaultedArray(new float[bezierCurves.length], renderingInterval));
     }
@@ -94,7 +97,8 @@ public class BezierCurveAnimator extends PathAnimatorBase {
      * @param renderingSteps The amount of rendering steps for the animation
      */
     public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves, @NotNull ParticleObject particle, int renderingSteps
+            int delay, @NotNull BezierCurve[] bezierCurves,
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, int renderingSteps
     ) {
         this(delay, bezierCurves, particle, defaultedArray(new int[bezierCurves.length], renderingSteps));
     }
@@ -113,7 +117,8 @@ public class BezierCurveAnimator extends PathAnimatorBase {
      * @param renderingInterval The number of blocks before placing a new render step
      */
     public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves, @NotNull ParticleObject particle, float[] renderingInterval
+            int delay, @NotNull BezierCurve[] bezierCurves,
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, float[] renderingInterval
     ) {
         super(delay, particle, renderingInterval[0]);
         if (bezierCurves.length == 0) {
@@ -139,7 +144,8 @@ public class BezierCurveAnimator extends PathAnimatorBase {
      * @param renderingSteps The amount of rendering steps for the animation
      */
     public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves, @NotNull ParticleObject particle, int[] renderingSteps
+            int delay, @NotNull BezierCurve[] bezierCurves,
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, int[] renderingSteps
     ) {
         super(delay, particle, renderingSteps[0]);
         if (bezierCurves.length == 0) {

--- a/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
@@ -30,6 +30,7 @@ public class BezierCurveAnimator extends PathAnimatorBase {
     protected DrawInterceptor<BezierCurveAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
     public enum OnRenderStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
+
     /**
      * Constructor for the bézier animation. This constructor is
      * meant to be used in the case that you want a good consistent
@@ -176,18 +177,6 @@ public class BezierCurveAnimator extends PathAnimatorBase {
         this.duringRenderingSteps = animator.duringRenderingSteps;
     }
 
-    /** Gets the distance needed to travel from the starting bézier curve to the ending bézier curve
-     *
-     * @return The distance between the starting bézier curve & ending bézier curve
-     */
-    public float getDistance() {
-        float sumDistance = 0;
-        for (BezierCurve bezierCurve : this.bezierCurves) {
-            sumDistance += bezierCurve.length(this.convertIntervalToSteps());
-        }
-        return sumDistance;
-    }
-
     /** Sets the animation trimming which accepts a start trim or
      * an ending trim. The trim parts have to be integer values
      *
@@ -226,15 +215,6 @@ public class BezierCurveAnimator extends PathAnimatorBase {
         // TODO: choose this value better, perhaps based on distance between start/end or start/controls/end?
         float distance = bezierCurve.length(100);
         return (int) Math.ceil(distance / interval);
-    }
-
-    @Override
-    protected int scheduleGetAmount() {
-        int sumSteps = 0;
-        for (int i : this.renderingSteps) {
-            sumSteps += i;
-        }
-        return sumSteps;
     }
 
     @Override

--- a/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
@@ -30,9 +30,9 @@ public class CircularAnimator extends PathAnimatorBase {
 
     private float tempDiffStore;
 
-    protected DrawInterceptor<CircularAnimator, onRenderingStep> duringRenderingSteps = DrawInterceptor.identity();
+    protected DrawInterceptor<CircularAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
-    public enum onRenderingStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
+    public enum OnRenderStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
 
     /**
      * Constructor for the circular animation. This constructor is
@@ -227,9 +227,9 @@ public class CircularAnimator extends PathAnimatorBase {
         Vector3f pos = calculatePoint(currAngle);
         this.allocateToScheduler();
         for (int i = 0; i < particleAmount ; i++) {
-            InterceptData<onRenderingStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), pos, i);
-            if (!((boolean) interceptData.getMetadata(onRenderingStep.SHOULD_DRAW_STEP))) continue;
-            pos = (Vector3f) interceptData.getMetadata(onRenderingStep.RENDERING_POSITION);
+            InterceptData<OnRenderStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), pos, i);
+            if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
+            pos = (Vector3f) interceptData.getMetadata(OnRenderStep.RENDERING_POSITION);
             this.handleDrawingStep(renderer, i, pos);
             currAngle += this.clockwise ? angleInterval : -angleInterval;
             currAngle = (float) ((currAngle + Math.TAU) % Math.TAU);
@@ -243,10 +243,7 @@ public class CircularAnimator extends PathAnimatorBase {
                 this.radius * trigTable.getSine(currAngle),
                 0
         );
-        pos = pos
-                .rotateZ(this.rotation.z)
-                .rotateY(this.rotation.y)
-                .rotateX(this.rotation.x);
+        pos = pos.rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
         return pos.add(this.center);
     }
 
@@ -257,18 +254,18 @@ public class CircularAnimator extends PathAnimatorBase {
      *
      * @param duringRenderingSteps the new interceptor to execute before drawing the individual steps
      */
-    public void setDuringRenderingSteps(DrawInterceptor<CircularAnimator, onRenderingStep> duringRenderingSteps) {
+    public void setDuringRenderingSteps(DrawInterceptor<CircularAnimator, OnRenderStep> duringRenderingSteps) {
         this.duringRenderingSteps = Optional.ofNullable(duringRenderingSteps).orElse(DrawInterceptor.identity());
     }
 
-    protected InterceptData<onRenderingStep> doBeforeStep(
+    protected InterceptData<OnRenderStep> doBeforeStep(
             ServerWorld world, Vector3f position, int currStep
     ) {
-        InterceptData<onRenderingStep> interceptData = new InterceptData<>(
-                world, null, currStep, onRenderingStep.class
+        InterceptData<OnRenderStep> interceptData = new InterceptData<>(
+                world, null, currStep, OnRenderStep.class
         );
-        interceptData.addMetadata(onRenderingStep.RENDERING_POSITION, position);
-        interceptData.addMetadata(onRenderingStep.SHOULD_DRAW_STEP, true);
+        interceptData.addMetadata(OnRenderStep.RENDERING_POSITION, position);
+        interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
@@ -223,8 +223,10 @@ public class CircularAnimator extends PathAnimatorBase {
         this.allocateToScheduler();
         for (int i = 0; i < particleAmount ; i++) {
             InterceptData<OnRenderStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), pos, i);
-            if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
-            pos = (Vector3f) interceptData.getMetadata(OnRenderStep.RENDERING_POSITION);
+            if (!interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP, true)) {
+                continue;
+            }
+            pos = interceptData.getMetadata(OnRenderStep.RENDERING_POSITION, pos);
             this.handleDrawingStep(renderer, i, pos);
             currAngle += this.clockwise ? angleInterval : -angleInterval;
             currAngle = (float) ((currAngle + Math.TAU) % Math.TAU);

--- a/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
@@ -202,11 +202,6 @@ public class CircularAnimator extends PathAnimatorBase {
         return (int) (Math.ceil(this.tempDiffStore / this.renderingInterval) + 1) * this.revolutions;
     }
 
-    @Override
-    protected int scheduleGetAmount() {
-        return this.renderingSteps * this.revolutions;
-    }
-
     /**
      * This method is used for beginning the animation logic.
      * It accepts the server world as a parameter. Unlike most

--- a/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
@@ -48,7 +48,7 @@ public class CircularAnimator extends PathAnimatorBase {
      */
     public CircularAnimator(
             int delay, float radius, @NotNull  Vector3f center, @NotNull Vector3f rotation,
-            @NotNull ParticleObject particle, int renderingSteps
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, int renderingSteps
     ) {
         super(delay, particle, renderingSteps);
         this.setRadius(radius);
@@ -72,7 +72,7 @@ public class CircularAnimator extends PathAnimatorBase {
      */
     public CircularAnimator(
             int delay, float radius, @NotNull  Vector3f center, @NotNull Vector3f rotation,
-            @NotNull ParticleObject particle, float renderingInterval
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval
     ) {
         super(delay, particle, renderingInterval);
         this.setRadius(radius);

--- a/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/CircularAnimator.java
@@ -198,7 +198,7 @@ public class CircularAnimator extends PathAnimatorBase {
      * @return The converted step
      */
     @Override
-    public int convertToSteps() {
+    public int convertIntervalToSteps() {
         return (int) (Math.ceil(this.tempDiffStore / this.renderingInterval) + 1) * this.revolutions;
     }
 
@@ -218,7 +218,7 @@ public class CircularAnimator extends PathAnimatorBase {
         float differenceAngle = this.trimming.getEnd() - startAngle;
         this.tempDiffStore = differenceAngle;
 
-        int particleAmount = this.renderingSteps == 0 ? this.convertToSteps() : this.renderingSteps * this.revolutions;
+        int particleAmount = this.renderingSteps == 0 ? this.convertIntervalToSteps() : this.renderingSteps * this.revolutions;
         float angleInterval = this.renderingInterval == 0 ? (
                 ((differenceAngle) / (this.renderingSteps - 1)) * this.revolutions
         ): this.renderingInterval * this.revolutions;

--- a/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
@@ -246,8 +246,10 @@ public class EllipseAnimator extends PathAnimatorBase {
         this.allocateToScheduler();
         for (int i = 0; i < particleAmount; i++) {
             InterceptData<OnRenderStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), pos, i);
-            if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
-            pos = (Vector3f) interceptData.getMetadata(OnRenderStep.RENDERING_POSITION);
+            if (!interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP, true)) {
+                continue;
+            }
+            pos = interceptData.getMetadata(OnRenderStep.RENDERING_POSITION, pos);
             this.handleDrawingStep(renderer, i, pos);
             currAngle += this.clockwise ? angleInterval : -angleInterval;
             currAngle = (float) ((currAngle + Math.TAU) % Math.TAU);

--- a/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
@@ -49,7 +49,7 @@ public class EllipseAnimator extends PathAnimatorBase {
      */
     public EllipseAnimator(
             int delay, float radius, @NotNull  Vector3f center, @NotNull Vector3f rotation,
-            float stretch, @NotNull ParticleObject particle, int renderingSteps
+            float stretch, @NotNull ParticleObject<? extends ParticleObject<?>> particle, int renderingSteps
     ) {
         super(delay, particle, renderingSteps);
         this.setRadius(radius);
@@ -75,7 +75,7 @@ public class EllipseAnimator extends PathAnimatorBase {
      */
     public EllipseAnimator(
             int delay, float radius, @NotNull  Vector3f center, @NotNull Vector3f rotation,
-            float stretch, @NotNull ParticleObject particle, float renderingInterval
+            float stretch, @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval
     ) {
         super(delay, particle, renderingInterval);
         this.setRadius(radius);

--- a/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
@@ -30,9 +30,9 @@ public class EllipseAnimator extends PathAnimatorBase {
     protected float stretch;
 
     private float tempDiffStore;
-    private DrawInterceptor<EllipseAnimator, onRenderingStep> duringRenderingSteps = DrawInterceptor.identity();
+    private DrawInterceptor<EllipseAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
-    public enum onRenderingStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
+    public enum OnRenderStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
 
     /**
      * Constructor for the ellipse animation. This constructor is
@@ -250,9 +250,9 @@ public class EllipseAnimator extends PathAnimatorBase {
         Vector3f pos = calculatePoint(currAngle);
         this.allocateToScheduler();
         for (int i = 0; i < particleAmount; i++) {
-            InterceptData<onRenderingStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), pos, i);
-            if (!((boolean) interceptData.getMetadata(onRenderingStep.SHOULD_DRAW_STEP))) continue;
-            pos = (Vector3f) interceptData.getMetadata(onRenderingStep.RENDERING_POSITION);
+            InterceptData<OnRenderStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), pos, i);
+            if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
+            pos = (Vector3f) interceptData.getMetadata(OnRenderStep.RENDERING_POSITION);
             this.handleDrawingStep(renderer, i, pos);
             currAngle += this.clockwise ? angleInterval : -angleInterval;
             currAngle = (float) ((currAngle + Math.TAU) % Math.TAU);
@@ -267,7 +267,7 @@ public class EllipseAnimator extends PathAnimatorBase {
      *
      * @param duringRenderingSteps the new interceptor to execute before drawing the individual steps
      */
-    public void setDuringRenderingSteps(DrawInterceptor<EllipseAnimator, onRenderingStep> duringRenderingSteps) {
+    public void setDuringRenderingSteps(DrawInterceptor<EllipseAnimator, OnRenderStep> duringRenderingSteps) {
         this.duringRenderingSteps = Optional.ofNullable(duringRenderingSteps).orElse(DrawInterceptor.identity());
     }
 
@@ -284,14 +284,14 @@ public class EllipseAnimator extends PathAnimatorBase {
         return pos.add(this.center);
     }
 
-    protected InterceptData<onRenderingStep> doBeforeStep(
+    protected InterceptData<OnRenderStep> doBeforeStep(
             ServerWorld world, Vector3f position, int currStep
     ) {
-        InterceptData<onRenderingStep> interceptData = new InterceptData<>(
-                world, null, currStep, onRenderingStep.class
+        InterceptData<OnRenderStep> interceptData = new InterceptData<>(
+                world, null, currStep, OnRenderStep.class
         );
-        interceptData.addMetadata(onRenderingStep.RENDERING_POSITION, position);
-        interceptData.addMetadata(onRenderingStep.SHOULD_DRAW_STEP, true);
+        interceptData.addMetadata(OnRenderStep.RENDERING_POSITION, position);
+        interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
@@ -225,11 +225,6 @@ public class EllipseAnimator extends PathAnimatorBase {
         return (int) (Math.ceil(this.tempDiffStore / this.renderingInterval) + 1) * this.revolutions;
     }
 
-    @Override
-    protected int scheduleGetAmount() {
-        return this.renderingSteps * this.revolutions;
-    }
-
     /**
      * This method is used for beginning the animation logic.
      * It accepts the server world as a parameter. Unlike most

--- a/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/EllipseAnimator.java
@@ -221,7 +221,7 @@ public class EllipseAnimator extends PathAnimatorBase {
      * @return The converted step
      */
     @Override
-    public int convertToSteps() {
+    public int convertIntervalToSteps() {
         return (int) (Math.ceil(this.tempDiffStore / this.renderingInterval) + 1) * this.revolutions;
     }
 
@@ -241,7 +241,7 @@ public class EllipseAnimator extends PathAnimatorBase {
         float differenceAngle = this.trimming.getEnd() - startAngle;
         this.tempDiffStore = differenceAngle;
 
-        int particleAmount = this.renderingSteps == 0 ? this.convertToSteps() : this.renderingSteps * this.revolutions;
+        int particleAmount = this.renderingSteps == 0 ? this.convertIntervalToSteps() : this.renderingSteps * this.revolutions;
         float angleInterval = this.renderingInterval == 0 ? (
                 ((differenceAngle) / (this.renderingSteps - 1)) * this.revolutions
         ): this.renderingInterval * this.revolutions;

--- a/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
@@ -25,9 +25,9 @@ public class LinearAnimator extends PathAnimatorBase {
     protected float[] renderingInterval;
     protected AnimationTrimming<Integer> trimming = new AnimationTrimming<>(0, -1);
 
-    protected DrawInterceptor<LinearAnimator, onRenderingStep> duringRenderingSteps = DrawInterceptor.identity();
+    protected DrawInterceptor<LinearAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
-    public enum onRenderingStep {SHOULD_DRAW_STEP, CURRENT_ENDPOINT, RENDERING_POSITION}
+    public enum OnRenderStep {SHOULD_DRAW_STEP, CURRENT_ENDPOINT, RENDERING_POSITION}
 
     /** Constructor for the linear animation. This constructor is
      * meant to be used in the case that you want a constant number
@@ -280,10 +280,10 @@ public class LinearAnimator extends PathAnimatorBase {
                 float newZ = curr.z + (dirZ * particleInterval);
                 curr = new Vector3f(newX, newY, newZ);
                 if (i < startStep) continue;
-                InterceptData<onRenderingStep> interceptData =
+                InterceptData<OnRenderStep> interceptData =
                         this.doBeforeStep(renderer.getServerWorld(), endpointIndex, curr, currStep);
-                if (!((boolean) interceptData.getMetadata(onRenderingStep.SHOULD_DRAW_STEP))) continue;
-                curr = (Vector3f) interceptData.getMetadata(onRenderingStep.RENDERING_POSITION);
+                if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
+                curr = (Vector3f) interceptData.getMetadata(OnRenderStep.RENDERING_POSITION);
                 this.handleDrawingStep(renderer, i, curr);
             }
         }
@@ -296,19 +296,19 @@ public class LinearAnimator extends PathAnimatorBase {
      *
      * @param duringRenderingSteps the new interceptor to execute before drawing the individual steps
      */
-    public void setDuringRenderingSteps(DrawInterceptor<LinearAnimator, onRenderingStep> duringRenderingSteps) {
+    public void setDuringRenderingSteps(DrawInterceptor<LinearAnimator, OnRenderStep> duringRenderingSteps) {
         this.duringRenderingSteps = Optional.ofNullable(duringRenderingSteps).orElse(DrawInterceptor.identity());
     }
 
-    protected InterceptData<onRenderingStep> doBeforeStep(
+    protected InterceptData<OnRenderStep> doBeforeStep(
             ServerWorld world, int currEndpointIndex, Vector3f position, int currStep
     ) {
-        InterceptData<onRenderingStep> interceptData = new InterceptData<>(
-                world, null, currStep, onRenderingStep.class
+        InterceptData<OnRenderStep> interceptData = new InterceptData<>(
+                world, null, currStep, OnRenderStep.class
         );
-        interceptData.addMetadata(onRenderingStep.RENDERING_POSITION, position);
-        interceptData.addMetadata(onRenderingStep.CURRENT_ENDPOINT, currEndpointIndex);
-        interceptData.addMetadata(onRenderingStep.SHOULD_DRAW_STEP, true);
+        interceptData.addMetadata(OnRenderStep.RENDERING_POSITION, position);
+        interceptData.addMetadata(OnRenderStep.CURRENT_ENDPOINT, currEndpointIndex);
+        interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
@@ -233,15 +233,6 @@ public class LinearAnimator extends PathAnimatorBase {
     }
 
     @Override
-    protected int scheduleGetAmount() {
-        int sumSteps = 0;
-        for (int i : this.renderingSteps) {
-            sumSteps += i;
-        }
-        return sumSteps;
-    }
-
-    @Override
     public void beginAnimation(ApelServerRenderer renderer) throws SeqDuplicateException, SeqMissingException {
         int particleAmount;
         float particleInterval;

--- a/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
@@ -192,7 +192,7 @@ public class LinearAnimator extends PathAnimatorBase {
     public AnimationTrimming<Integer> setTrimming(AnimationTrimming<Integer> trimming) {
         int startStep = trimming.getStart();
         int endStep = trimming.getEnd();
-        if (startStep <= 0 || endStep >= this.getRenderSteps() || startStep >= endStep) {
+        if (startStep <= 0 || endStep >= this.getRenderingSteps() || startStep >= endStep) {
             throw new IllegalArgumentException("Invalid animation trimming range");
         }
         AnimationTrimming<Integer> prevTrimming = this.trimming;
@@ -222,7 +222,7 @@ public class LinearAnimator extends PathAnimatorBase {
 
 
     @Override
-    public int convertToSteps() {
+    public int convertIntervalToSteps() {
         int steps = 0;
         for (int i = 0; i < this.endpoints.length - 1; i++) {
             float distance = this.endpoints[i].distance(this.endpoints[i + 1]);
@@ -259,7 +259,7 @@ public class LinearAnimator extends PathAnimatorBase {
             if (particleInterval == 0.0f) {
                 particleInterval = (this.getDistance() / particleAmount) * (this.endpoints.length - 1);
             } else {
-                particleAmount = this.convertToSteps();
+                particleAmount = this.convertIntervalToSteps();
             }
             Vector3f startPos = this.endpoints[endpointIndex - 1];
             float dist = this.getDistance();

--- a/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
@@ -40,8 +40,8 @@ public class LinearAnimator extends PathAnimatorBase {
      * @param renderingSteps The amount of rendering steps for the animation
      */
     public LinearAnimator(
-            int delay, @NotNull Vector3f start, @NotNull Vector3f end, @NotNull ParticleObject particle,
-            int renderingSteps
+            int delay, @NotNull Vector3f start, @NotNull Vector3f end,
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, int renderingSteps
     ) {
         this(delay, new Vector3f[]{start, end}, particle, new int[]{renderingSteps});
     }
@@ -60,8 +60,8 @@ public class LinearAnimator extends PathAnimatorBase {
      * @param renderingInterval The number of blocks before placing a new render step
      */
     public LinearAnimator(
-            int delay, @NotNull Vector3f start, @NotNull Vector3f end, @NotNull ParticleObject particle,
-            float renderingInterval
+            int delay, @NotNull Vector3f start, @NotNull Vector3f end,
+            @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval
     ) {
         this(delay, new Vector3f[]{start, end}, particle, new float[]{renderingInterval});
     }
@@ -80,7 +80,8 @@ public class LinearAnimator extends PathAnimatorBase {
      * @param renderingInterval The distance, in blocks, between rendering steps
      */
     public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject particle, float renderingInterval
+            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
+            float renderingInterval
     ) {
         // There should be one fewer interval entries than endpoints, since each pair needs an interval
         this(delay, endpoints, particle, defaultedArray(new float[endpoints.length - 1], renderingInterval));
@@ -98,7 +99,8 @@ public class LinearAnimator extends PathAnimatorBase {
      * @param renderingSteps The amount of rendering steps between each pair of endpoints
      */
     public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject particle, int renderingSteps
+            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
+            int renderingSteps
     ) {
         // There should be one fewer step entries than endpoints since each segment needs steps
         this(delay, endpoints, particle, defaultedArray(new int[endpoints.length - 1], renderingSteps));
@@ -118,7 +120,8 @@ public class LinearAnimator extends PathAnimatorBase {
      * @param renderingInterval The number of blocks before placing a new render step
      */
     public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject particle, float[] renderingInterval
+            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
+            float[] renderingInterval
     ) {
         super(delay, particle, renderingInterval[0]);
         if ((renderingInterval.length - 1) == endpoints.length) {
@@ -141,7 +144,7 @@ public class LinearAnimator extends PathAnimatorBase {
      * @param renderingSteps The amount of rendering steps for the animation
      */
     public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject particle, int[] renderingSteps
+            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle, int[] renderingSteps
     ) {
         super(delay, particle, renderingSteps[0]);
         if ((renderingSteps.length - 1) == endpoints.length) {

--- a/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
@@ -28,9 +28,9 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
     protected List<PathAnimatorBase> animators = new ArrayList<>();
     protected List<Integer> delays = new ArrayList<>();
 
-    protected DrawInterceptor<ParallelAnimator, onPathAnimatorRendering> onAnimatorRendering = DrawInterceptor.identity();
+    protected DrawInterceptor<ParallelAnimator, OnRenderPathAnimator> onAnimatorRendering = DrawInterceptor.identity();
 
-    public enum onPathAnimatorRendering {PATH_ANIMATOR, SHOULD_RENDER_ANIMATOR, DELAY}
+    public enum OnRenderPathAnimator {PATH_ANIMATOR, SHOULD_RENDER_ANIMATOR, DELAY}
 
     /** Constructor for the parallel animation. This constructor is
      * meant to be used in the case that you want to supply a specific
@@ -184,12 +184,12 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
         int step = 0;
         for (PathAnimatorBase animator : this.animators) {
             step++;
-            InterceptData<onPathAnimatorRendering> interceptData = this.doBeforeStep(
+            InterceptData<OnRenderPathAnimator> interceptData = this.doBeforeStep(
                     renderer.getServerWorld(), animator, getDelayForAnimator(step), step
             );
-            if (!((boolean) interceptData.getMetadata(onPathAnimatorRendering.SHOULD_RENDER_ANIMATOR))) continue;
-            animator = (PathAnimatorBase) interceptData.getMetadata(onPathAnimatorRendering.PATH_ANIMATOR);
-            int delayForAnimator = (int) interceptData.getMetadata(onPathAnimatorRendering.DELAY);
+            if (!((boolean) interceptData.getMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR))) continue;
+            animator = (PathAnimatorBase) interceptData.getMetadata(OnRenderPathAnimator.PATH_ANIMATOR);
+            int delayForAnimator = (int) interceptData.getMetadata(OnRenderPathAnimator.DELAY);
             int delayForAnimatorInUse = this.getDelayForAnimator(step);
             if (delayForAnimator != delayForAnimatorInUse) {
                 this.delays.set(step - 1, delayForAnimator);
@@ -233,19 +233,19 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
      *
      * @param duringRenderingSteps the new interceptor to execute before drawing the individual steps
      */
-    public void setOnAnimatorRendering(DrawInterceptor<ParallelAnimator, onPathAnimatorRendering> duringRenderingSteps) {
+    public void setOnAnimatorRendering(DrawInterceptor<ParallelAnimator, OnRenderPathAnimator> duringRenderingSteps) {
         this.onAnimatorRendering = Optional.ofNullable(duringRenderingSteps).orElse(DrawInterceptor.identity());
     }
 
-    protected InterceptData<onPathAnimatorRendering> doBeforeStep(
+    protected InterceptData<OnRenderPathAnimator> doBeforeStep(
             ServerWorld world, PathAnimatorBase pathAnimatorBase, int delay, int currStep
     ) {
-        InterceptData<onPathAnimatorRendering> interceptData = new InterceptData<>(
-                world, null, currStep, onPathAnimatorRendering.class
+        InterceptData<OnRenderPathAnimator> interceptData = new InterceptData<>(
+                world, null, currStep, OnRenderPathAnimator.class
         );
-        interceptData.addMetadata(onPathAnimatorRendering.PATH_ANIMATOR, pathAnimatorBase);
-        interceptData.addMetadata(onPathAnimatorRendering.DELAY, delay);
-        interceptData.addMetadata(onPathAnimatorRendering.SHOULD_RENDER_ANIMATOR, true);
+        interceptData.addMetadata(OnRenderPathAnimator.PATH_ANIMATOR, pathAnimatorBase);
+        interceptData.addMetadata(OnRenderPathAnimator.DELAY, delay);
+        interceptData.addMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR, true);
         this.onAnimatorRendering.apply(interceptData, this);
         return interceptData;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
@@ -142,7 +142,7 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
     /** This method is DEPRECATED and SHOULD NOT BE USED */
     @Override
     @Deprecated
-    public int setRenderSteps(int steps) {
+    public int setRenderingSteps(int steps) {
         throw new UnsupportedOperationException("Parallel Animators cannot set rendering steps");
     }
 
@@ -156,12 +156,12 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
     /** This method is DEPRECATED and SHOULD NOT BE USED */
     @Override
     @Deprecated
-    public float setRenderInterval(float interval) {
+    public float setRenderingInterval(float interval) {
         throw new UnsupportedOperationException("Parallel Animators cannot set rendering interval");
     }
 
     @Override
-    public int convertToSteps() {
+    public int convertIntervalToSteps() {
         return this.animators.size();
     }
 
@@ -211,12 +211,12 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
             Apel.DRAW_EXECUTOR.submit(func);
             return;
         }
-        if (this.processSpeed <= 1) {
+        if (this.processingSpeed <= 1) {
             Apel.SCHEDULER.allocateNewStep(
                     this, new ScheduledStep(delayUsed, new Runnable[]{func})
             );
             return;
-        } else if (step % this.processSpeed != 0) {
+        } else if (step % this.processingSpeed != 0) {
             this.storedFuncsBuffer.add(func);
             return;
         }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
@@ -187,8 +187,10 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
             InterceptData<OnRenderPathAnimator> interceptData = this.doBeforeStep(
                     renderer.getServerWorld(), animator, getDelayForAnimator(step), step
             );
-            if (!((boolean) interceptData.getMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR))) continue;
-            animator = (PathAnimatorBase) interceptData.getMetadata(OnRenderPathAnimator.PATH_ANIMATOR);
+            if (!interceptData.getMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR, true)) {
+                continue;
+            }
+            animator = interceptData.getMetadata(OnRenderPathAnimator.PATH_ANIMATOR, animator);
             int delayForAnimator = (int) interceptData.getMetadata(OnRenderPathAnimator.DELAY);
             int delayForAnimatorInUse = this.getDelayForAnimator(step);
             if (delayForAnimator != delayForAnimatorInUse) {

--- a/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
@@ -149,7 +149,7 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
     /** This method is DEPRECATED and SHOULD NOT BE USED */
     @Deprecated
     @Override
-    public ParticleObject setParticleObject(@NotNull ParticleObject object) {
+    public ParticleObject<? extends ParticleObject<?>> setParticleObject(@NotNull ParticleObject<? extends ParticleObject<?>> object) {
         throw new UnsupportedOperationException("Parallel Animators cannot set an individual particle object");
     }
 

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -108,6 +108,22 @@ public abstract class PathAnimatorBase {
         return this.renderingSteps;
     }
 
+    /** Sets the rendering steps to a new value. It resets the rendering interval
+     *  to 0.0f. And returns the previous rendering steps used
+     *
+     * @param steps The new rendering steps to set
+     * @return The previous rendering interval
+     */
+    public int setRenderSteps(int steps) {
+        if (steps < 0) {
+            throw new IllegalArgumentException("Rendering Steps is not positive or equals to 0");
+        }
+        int prevRenderStep = this.renderingSteps;
+        this.renderingSteps = steps;
+        this.renderingInterval = 0.0f;
+        return prevRenderStep;
+    }
+
     /** Gets the interval of blocks per particle object render.
      * Which can be zero indicating that there wasn't any
      * interval specified
@@ -118,6 +134,22 @@ public abstract class PathAnimatorBase {
         return this.renderingInterval;
     }
 
+    /** Sets the rendering interval to a new value. It resets the rendering steps
+     *  to 0. And returns the previous rendering interval used
+     *
+     * @param interval The new rendering interval to set
+     * @return The previous rendering interval
+     */
+    public float setRenderInterval(float interval) {
+        if (interval < 0) {
+            throw new IllegalArgumentException("Rendering Interval is not positive or equals to 0");
+        }
+        float prevInterval = this.renderingInterval;
+        this.renderingInterval = interval;
+        this.renderingSteps = 0;
+        return prevInterval;
+    }
+
     /** Gets the delay per rendering step, this can be zero indicating
      * that the animation plays in an instant; the amount of delay is
      * also controlled via processing speed
@@ -126,7 +158,7 @@ public abstract class PathAnimatorBase {
      * @return The amount of rendering steps
      */
     public int getDelay() {
-        return this.renderingSteps;
+        return this.delay;
     }
 
     /** Sets the delay per rendering step to a new value. And
@@ -165,36 +197,14 @@ public abstract class PathAnimatorBase {
         return particleObject;
     }
 
-    /** Sets the rendering interval to a new value. It resets the rendering steps
-     *  to 0. And returns the previous rendering interval used
+    /** Gets the processing speed. Which is measured in rs/st and dictates how many functions
+     * to execute per rendering step. By default, it is set to 1 rs/st
      *
-     * @param interval The new rendering interval to set
-     * @return The previous rendering interval
-    */
-    public float setRenderInterval(float interval) {
-        if (interval < 0) {
-            throw new IllegalArgumentException("Rendering Interval is not positive or equals to 0");
-        }
-        float prevInterval = this.renderingInterval;
-        this.renderingInterval = interval;
-        this.renderingSteps = 0;
-        return prevInterval;
-    }
-
-    /** Sets the rendering steps to a new value. It resets the rendering interval
-     *  to 0.0f. And returns the previous rendering steps used
-     *
-     * @param steps The new rendering steps to set
-     * @return The previous rendering interval
-    */
-    public int setRenderSteps(int steps) {
-        if (steps < 0) {
-            throw new IllegalArgumentException("Rendering Steps is not positive or equals to 0");
-        }
-        int prevRenderStep = this.renderingSteps;
-        this.renderingSteps = steps;
-        this.renderingInterval = 0.0f;
-        return prevRenderStep;
+     * @see PathAnimatorBase#getDelay()
+     * @return The processing speed used
+     */
+    public int getProcessingSpeed() {
+        return this.processSpeed;
     }
 
     /** Sets the processing speed to allow for even faster animations on larger rendering steps.
@@ -217,16 +227,6 @@ public abstract class PathAnimatorBase {
         int prevProcessSpeed = this.processSpeed;
         this.processSpeed = speed;
         return prevProcessSpeed;
-    }
-
-    /** Gets the processing speed. Which is measured in rs/st and dictates how many functions
-     * to execute per rendering step. By default, it is set to 1 rs/st
-     *
-     * @see PathAnimatorBase#getDelay()
-     * @return The processing speed used
-     */
-    public int getProcessingSpeed() {
-        return this.processSpeed;
     }
 
     /** Does the calculations to convert from an interval to rendering steps

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -26,7 +26,7 @@ public abstract class PathAnimatorBase {
     protected int renderingSteps = 0;
     protected int delay;
     protected int processSpeed = 1;
-    protected ParticleObject particleObject;
+    protected ParticleObject<? extends ParticleObject<?>> particleObject;
 
     protected List<Runnable> storedFuncsBuffer = new ArrayList<>();
 
@@ -42,7 +42,7 @@ public abstract class PathAnimatorBase {
      * @param renderingSteps The rendering steps to use
      * @see PathAnimatorBase#PathAnimatorBase(int, ParticleObject, float)
     */
-    public PathAnimatorBase(int delay, ParticleObject particleObject, int renderingSteps) {
+    public PathAnimatorBase(int delay, ParticleObject<? extends ParticleObject<?>> particleObject, int renderingSteps) {
         this.setDelay(delay);
         this.setParticleObject(particleObject);
         this.setRenderSteps(renderingSteps);
@@ -62,7 +62,7 @@ public abstract class PathAnimatorBase {
      * @param renderingInterval The rendering interval to use, which is how many blocks per new rendering step
      * @see PathAnimatorBase#PathAnimatorBase(int, ParticleObject, int)
      */
-    public PathAnimatorBase(int delay, @NotNull ParticleObject particle, float renderingInterval) {
+    public PathAnimatorBase(int delay, @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval) {
         this.setDelay(delay);
         this.setParticleObject(particle);
         this.setRenderInterval(renderingInterval);
@@ -150,7 +150,7 @@ public abstract class PathAnimatorBase {
      *
      * @return The particle object
      */
-    public ParticleObject getParticleObject() {
+    public ParticleObject<?> getParticleObject() {
         return this.particleObject;
     }
 
@@ -159,8 +159,8 @@ public abstract class PathAnimatorBase {
      *
      * @return The previous amount of rendering steps
      */
-    public ParticleObject setParticleObject(@NotNull ParticleObject object) {
-        ParticleObject particleObject = this.particleObject;
+    public ParticleObject<?> setParticleObject(@NotNull ParticleObject<? extends ParticleObject<?>> object) {
+        ParticleObject<?> particleObject = this.particleObject;
         this.particleObject = object;
         return particleObject;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -91,12 +91,7 @@ public abstract class PathAnimatorBase {
      */
     public void allocateToScheduler() {
         if (this.delay == 0) return;
-        int steps = this.renderingSteps != 0 ? this.scheduleGetAmount() : this.convertIntervalToSteps();
-        Apel.SCHEDULER.allocateNewSequence(this, steps);
-    }
-
-    protected int scheduleGetAmount() {
-        return this.renderingSteps;
+        Apel.SCHEDULER.allocateNewSequence(this);
     }
 
     /** Gets the amount of rendering steps, which can be zero indicating

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
@@ -31,7 +31,8 @@ public class PointAnimator extends PathAnimatorBase {
      * @param particle The particle object to use
      * @param renderingSteps The rendering steps to use
     */
-    public PointAnimator(int delay, @NotNull ParticleObject particle, Vector3f origin, int renderingSteps) {
+    public PointAnimator(int delay, @NotNull ParticleObject<? extends ParticleObject<?>> particle, Vector3f origin,
+                         int renderingSteps) {
         super(delay, particle, renderingSteps);
         this.origin = origin;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
@@ -80,7 +80,9 @@ public class PointAnimator extends PathAnimatorBase {
         this.allocateToScheduler();
         for (int i = 0; i < this.renderingSteps; i++) {
             InterceptData<OnRenderStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), i);
-            if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
+            if (!interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP, true)) {
+                continue;
+            }
             this.handleDrawingStep(renderer, i, this.origin);
         }
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
@@ -20,9 +20,9 @@ import java.util.Optional;
 @SuppressWarnings("unused")
 public class PointAnimator extends PathAnimatorBase {
     protected Vector3f origin;
-    protected DrawInterceptor<PointAnimator, onRenderingStep> duringRenderingSteps = DrawInterceptor.identity();
+    protected DrawInterceptor<PointAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
-    public enum onRenderingStep {SHOULD_DRAW_STEP}
+    public enum OnRenderStep {SHOULD_DRAW_STEP}
 
     /** Constructor for the point animator. It basically animates the object in a certain place.
      * The place is called the origin, which is only a point (hence the point animator)
@@ -79,8 +79,8 @@ public class PointAnimator extends PathAnimatorBase {
     public void beginAnimation(ApelServerRenderer renderer) throws SeqDuplicateException, SeqMissingException {
         this.allocateToScheduler();
         for (int i = 0; i < this.renderingSteps; i++) {
-            InterceptData<onRenderingStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), i);
-            if (!((boolean) interceptData.getMetadata(onRenderingStep.SHOULD_DRAW_STEP))) continue;
+            InterceptData<OnRenderStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), i);
+            if (!((boolean) interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP))) continue;
             this.handleDrawingStep(renderer, i, this.origin);
         }
     }
@@ -91,15 +91,15 @@ public class PointAnimator extends PathAnimatorBase {
      *
      * @param duringRenderingSteps the new interceptor to execute before drawing the individual steps
      */
-    public void setDuringRenderingSteps(DrawInterceptor<PointAnimator, onRenderingStep> duringRenderingSteps) {
+    public void setDuringRenderingSteps(DrawInterceptor<PointAnimator, OnRenderStep> duringRenderingSteps) {
         this.duringRenderingSteps = Optional.ofNullable(duringRenderingSteps).orElse(DrawInterceptor.identity());
     }
 
-    protected InterceptData<onRenderingStep> doBeforeStep(ServerWorld world, int currStep) {
-        InterceptData<onRenderingStep> interceptData = new InterceptData<>(
-                world, null, currStep, onRenderingStep.class
+    protected InterceptData<OnRenderStep> doBeforeStep(ServerWorld world, int currStep) {
+        InterceptData<OnRenderStep> interceptData = new InterceptData<>(
+                world, null, currStep, OnRenderStep.class
         );
-        interceptData.addMetadata(onRenderingStep.SHOULD_DRAW_STEP, true);
+        interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
@@ -71,7 +71,7 @@ public class PointAnimator extends PathAnimatorBase {
     }
 
     @Override
-    public int convertToSteps() {
+    public int convertIntervalToSteps() {
         return this.renderingSteps;
     }
 

--- a/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
@@ -173,8 +173,10 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
             step++;
             InterceptData<OnRenderPathAnimator> interceptData =
                     this.doBeforeStep(renderer.getServerWorld(), animator, getDelayOfAnimator(step), step);
-            if (!((boolean) interceptData.getMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR))) continue;
-            animator = (PathAnimatorBase) interceptData.getMetadata(OnRenderPathAnimator.PATH_ANIMATOR);
+            if (!interceptData.getMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR, true)) {
+                continue;
+            }
+            animator = interceptData.getMetadata(OnRenderPathAnimator.PATH_ANIMATOR, animator);
             int delayForAnimator = (int) interceptData.getMetadata(OnRenderPathAnimator.DELAY);
             int delayForAnimatorInUse = this.getDelayOfAnimator(step);
             if (delayForAnimator != delayForAnimatorInUse) {

--- a/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
@@ -148,7 +148,7 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
     /** This method is DEPRECATED and SHOULD NOT BE USED */
     @Deprecated
     @Override
-    public ParticleObject setParticleObject(@NotNull ParticleObject object) {
+    public ParticleObject<? extends ParticleObject<?>> setParticleObject(@NotNull ParticleObject<? extends ParticleObject<?>> object) {
         throw new UnsupportedOperationException("Sequential Animators cannot set an individual particle object");
     }
 

--- a/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
@@ -27,9 +27,9 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
     protected List<PathAnimatorBase> animators = new ArrayList<>();
     protected List<Integer> delays = new ArrayList<>();
 
-    protected DrawInterceptor<SequentialAnimator, onPathAnimatorRendering> onAnimatorRendering = DrawInterceptor.identity();
+    protected DrawInterceptor<SequentialAnimator, OnRenderPathAnimator> onAnimatorRendering = DrawInterceptor.identity();
 
-    public enum onPathAnimatorRendering {PATH_ANIMATOR, SHOULD_RENDER_ANIMATOR, DELAY}
+    public enum OnRenderPathAnimator {PATH_ANIMATOR, SHOULD_RENDER_ANIMATOR, DELAY}
 
     /** Constructor for the parallel animation. This constructor is
      * meant to be used in the case that you want to supply a specific
@@ -171,11 +171,11 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
         PathAnimatorBase prev = null;
         for (PathAnimatorBase animator : this.animators) {
             step++;
-            InterceptData<onPathAnimatorRendering> interceptData =
+            InterceptData<OnRenderPathAnimator> interceptData =
                     this.doBeforeStep(renderer.getServerWorld(), animator, getDelayOfAnimator(step), step);
-            if (!((boolean) interceptData.getMetadata(onPathAnimatorRendering.SHOULD_RENDER_ANIMATOR))) continue;
-            animator = (PathAnimatorBase) interceptData.getMetadata(onPathAnimatorRendering.PATH_ANIMATOR);
-            int delayForAnimator = (int) interceptData.getMetadata(onPathAnimatorRendering.DELAY);
+            if (!((boolean) interceptData.getMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR))) continue;
+            animator = (PathAnimatorBase) interceptData.getMetadata(OnRenderPathAnimator.PATH_ANIMATOR);
+            int delayForAnimator = (int) interceptData.getMetadata(OnRenderPathAnimator.DELAY);
             int delayForAnimatorInUse = this.getDelayOfAnimator(step);
             if (delayForAnimator != delayForAnimatorInUse) {
                 this.delays.set(step - 1, delayForAnimator);
@@ -238,19 +238,19 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
      *
      * @param duringRenderingSteps the new interceptor to execute before drawing the individual steps
      */
-    public void setOnAnimatorRendering(DrawInterceptor<SequentialAnimator, onPathAnimatorRendering> duringRenderingSteps) {
+    public void setOnAnimatorRendering(DrawInterceptor<SequentialAnimator, OnRenderPathAnimator> duringRenderingSteps) {
         this.onAnimatorRendering = Optional.ofNullable(duringRenderingSteps).orElse(DrawInterceptor.identity());
     }
 
-    protected InterceptData<onPathAnimatorRendering> doBeforeStep(
+    protected InterceptData<OnRenderPathAnimator> doBeforeStep(
             ServerWorld world, PathAnimatorBase pathAnimatorBase, int delay, int currStep
     ) {
-        InterceptData<onPathAnimatorRendering> interceptData = new InterceptData<>(
-                world, null, currStep, onPathAnimatorRendering.class
+        InterceptData<OnRenderPathAnimator> interceptData = new InterceptData<>(
+                world, null, currStep, OnRenderPathAnimator.class
         );
-        interceptData.addMetadata(onPathAnimatorRendering.PATH_ANIMATOR, pathAnimatorBase);
-        interceptData.addMetadata(onPathAnimatorRendering.DELAY, delay);
-        interceptData.addMetadata(onPathAnimatorRendering.SHOULD_RENDER_ANIMATOR, true);
+        interceptData.addMetadata(OnRenderPathAnimator.PATH_ANIMATOR, pathAnimatorBase);
+        interceptData.addMetadata(OnRenderPathAnimator.DELAY, delay);
+        interceptData.addMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR, true);
         this.onAnimatorRendering.apply(interceptData, this);
         return interceptData;
     }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/SequentialAnimator.java
@@ -141,7 +141,7 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
     /** This method is DEPRECATED and SHOULD NOT BE USED */
     @Override
     @Deprecated
-    public int setRenderSteps(int steps) {
+    public int setRenderingSteps(int steps) {
         throw new UnsupportedOperationException("Sequential Animators cannot set rendering steps");
     }
 
@@ -155,12 +155,12 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
     /** This method is DEPRECATED and SHOULD NOT BE USED */
     @Override
     @Deprecated
-    public float setRenderInterval(float interval) {
+    public float setRenderingInterval(float interval) {
         throw new UnsupportedOperationException("Sequential Animators cannot set rendering interval");
     }
 
     @Override
-    public int convertToSteps() {
+    public int convertIntervalToSteps() {
         return this.animators.size();
     }
 
@@ -216,12 +216,12 @@ public class SequentialAnimator extends PathAnimatorBase implements TreePathAnim
             Apel.DRAW_EXECUTOR.submit(func);
             return;
         }
-        if (this.processSpeed <= 1) {
+        if (this.processingSpeed <= 1) {
             Apel.SCHEDULER.allocateNewStep(
                     this, new ScheduledStep(delayUsed, new Runnable[]{func})
             );
             return;
-        } else if (step % this.processSpeed != 0) {
+        } else if (step % this.processingSpeed != 0) {
             this.storedFuncsBuffer.add(func);
             return;
         }

--- a/src/main/java/net/mcbrincie/apel/lib/util/AnimationTrimming.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/AnimationTrimming.java
@@ -1,9 +1,9 @@
 package net.mcbrincie.apel.lib.util;
 
 /** The path animation trimming, which is a basic container that holds the trimming data for
- * the path animator to use, the trimming data varies from one path animator to the other.
- * For example, the circular path animator requires degrees as trimming, whereas the linear
- * path animator requires the steps for trimming
+ * the path animator to use.  Trimming data varies among path animators, for example, the circular
+ * path animator requires radian values when trimming, whereas the linear path animator requires
+ * the steps for trimming.
  *
  * @param <T> The type to use for the trimming (look up what type the path animator you target uses)
  */
@@ -40,7 +40,7 @@ public class AnimationTrimming<T> {
      * @return The previous start trimming value
      */
     public T setStart(T newStart) {
-        T prev = this.end;
+        T prev = this.start;
         this.start = newStart;
         return prev;
     }
@@ -51,8 +51,8 @@ public class AnimationTrimming<T> {
      * @return The previous ending trimming value
      */
     public T setEnd(T newEnd) {
-        T prev = this.start;
-        this.start = newEnd;
+        T prev = this.end;
+        this.end = newEnd;
         return prev;
     }
 

--- a/src/main/java/net/mcbrincie/apel/lib/util/scheduler/ApelScheduler.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/scheduler/ApelScheduler.java
@@ -27,7 +27,7 @@ public class ApelScheduler {
      *  than one sequence chunk
      *
      */
-    public void allocateNewSequence(PathAnimatorBase object, int amount) throws SeqDuplicateException {
+    public void allocateNewSequence(PathAnimatorBase object) throws SeqDuplicateException {
         this.scheduledTasks.add(new ScheduledSequence());
         this.animators.add(object);
     }

--- a/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
@@ -54,32 +54,4 @@ class LinearAnimatorTest {
         // (9 to -9) * 2 == 36
         assertEquals(726, steps);
     }
-
-    @Test
-    void testScheduleGetAmount() {
-        // Given a LinearAnimator with a rendering step count
-        LinearAnimator linearAnimator = new LinearAnimator(1, new Vector3f[]{
-                new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0),
-        }, POINT_WITH_NULL_PARTICLE, 400);
-
-        // When the total step count is requested by the scheduler allocation
-        int steps = linearAnimator.scheduleGetAmount();
-
-        // Then it is 400 per segment, or 1200 total
-        assertEquals(1200, steps);
-    }
-
-    @Test
-    void testScheduleGetAmountWithUniqueStepCounts() {
-        // Given a LinearAnimator with a rendering step count
-        LinearAnimator linearAnimator = new LinearAnimator(1, new Vector3f[]{
-                new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0),
-        }, POINT_WITH_NULL_PARTICLE, new int[]{400, 200, 100});
-
-        // When the total step count is requested by the scheduler allocation
-        int steps = linearAnimator.scheduleGetAmount();
-
-        // Then it is the sum of the values
-        assertEquals(700, steps);
-    }
 }

--- a/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
@@ -25,28 +25,28 @@ class LinearAnimatorTest {
     }
 
     @Test
-    void testConvertToSteps() {
+    void testConvertIntervalToSteps() {
         // Given a LinearAnimator with a rendering interval
         LinearAnimator linearAnimator = new LinearAnimator(1, new Vector3f[]{
                 new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0),
         }, POINT_WITH_NULL_PARTICLE, .04f);
 
         // When the distance is computed
-        int steps = linearAnimator.convertToSteps();
+        int steps = linearAnimator.convertIntervalToSteps();
 
         // Then it is 1425: (10 to -10) + (-10 to 9) + (9 to -9), or 20 + 19 + 18 == 57 / .04 == 1425.
         assertEquals(1425, steps);
     }
 
     @Test
-    void testConvertToStepsWithUniqueIntervals() {
+    void testConvertIntervalToStepsWithUniqueIntervals() {
         // Given a LinearAnimator with a rendering interval
         LinearAnimator linearAnimator = new LinearAnimator(1, new Vector3f[]{
                 new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0),
         }, POINT_WITH_NULL_PARTICLE, new float[]{.04f, .1f, .5f});
 
         // When the distance is computed
-        int steps = linearAnimator.convertToSteps();
+        int steps = linearAnimator.convertIntervalToSteps();
 
         // Then it is 726:
         // (10 to -10) * 25 == 500


### PR DESCRIPTION
This cleans up several things on animators in preparation to move to builders:
1. Use `ParticleObject<? extends ParticleObject<?>>` as the type.  This ensures that only classes inheriting from `ParticleObject` may be used when subclassing and using it generically.
2. The animation interceptor was using a camelCase name instead of PascalCase, so fix that across all animators.
3. `PathAnimatorBase` was somewhat disorganized with getters/setters, so order those to group getter/setter together.
4. There were a few mismatches between properties and getter/setter names, so align those.
5. Fixes bugs in AnimationTrimming where the wrong variables were set and returned.
6. Remove unused methods from `PathAnimatorBase` and `BezierCurveAnimator`.
7. Leverage `getMetadata`'s ability to default a value of a known type to prevent casting.
8. Simplifies `LinearAnimator` using the pattern from `BezierCurveAnimator`; they're identical in structure -- the only difference is the segment type.  There's possibility for future refactoring/inheritance/interface here.