### PR TITLE
Building animators

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/BezierCurveAnimator.java
@@ -2,16 +2,16 @@ package net.mcbrincie.apel.lib.animators;
 
 import net.mcbrincie.apel.lib.exceptions.SeqDuplicateException;
 import net.mcbrincie.apel.lib.exceptions.SeqMissingException;
-import net.mcbrincie.apel.lib.objects.ParticleObject;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.AnimationTrimming;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
 import net.mcbrincie.apel.lib.util.math.bezier.BezierCurve;
 import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /** The Bézier curve animator which is used for curved paths, it accepts two or multiple different bézier curves,
@@ -22,142 +22,23 @@ import java.util.Optional;
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class BezierCurveAnimator extends PathAnimatorBase {
-    protected BezierCurve[] bezierCurves;
-    protected int[] renderingSteps;
-    protected float[] renderingInterval;
-    protected AnimationTrimming<Integer> trimming = new AnimationTrimming<>(0, -1);
+    protected List<BezierCurve> bezierCurves;
+    protected List<Integer> stepsForCurves;
+    protected AnimationTrimming<Integer> trimming;
 
     protected DrawInterceptor<BezierCurveAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
     public enum OnRenderStep {SHOULD_DRAW_STEP, RENDERING_POSITION}
 
-    /**
-     * Constructor for the bézier animation. This constructor is
-     * meant to be used in the case that you want a good consistent
-     * looking particle curve. The amount is dynamic that can cause
-     * performance issues for larger distances (The higher the interval,
-     * the fewer particles are rendered, and it is also applied vice versa)
-     *
-     * @param delay The delay between each particle object render
-     * @param curve The bézier curve
-     * @param particle The particle to use
-     * @param renderingInterval The number of blocks before placing a new render step
-     */
-    public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve curve, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
-            float renderingInterval
-    ) {
-        this(delay, new BezierCurve[]{curve}, particle, new float[]{renderingInterval});
+    public static <B extends Builder<B>> Builder<B> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the bézier curve animation. This constructor is
-     * meant to be used in the case that you want a constant number
-     * of particles. It doesn't look pretty at large distances tho
-     *
-     * @param delay The delay between each particle object render
-     * @param curve The bézier curve
-     * @param particle The particle to use
-     * @param renderingSteps The amount of rendering steps for the animation
-     */
-    public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve curve, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
-            int renderingSteps
-    ) {
-        this(delay, new BezierCurve[]{curve}, particle, new int[]{renderingSteps});
-    }
-
-    /**
-     * Constructor for the bézier animation. This constructor is
-     * meant to be used in the case that you want a good consistent
-     * looking particle line & also want to create multiple bézier curves.
-     * Because of the interval, the amount is dynamic that can cause
-     * performance issues for larger distances (The higher the interval
-     * the fewer particles are rendered, and it is also applied vice versa)
-     *
-     * @param delay The delay between each particle object render
-     * @param bezierCurves The bézier curves
-     * @param particle The particle to use
-     * @param renderingInterval The number of blocks before placing a new render step
-     */
-    public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves,
-            @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval
-    ) {
-        this(delay, bezierCurves, particle, defaultedArray(new float[bezierCurves.length], renderingInterval));
-    }
-
-    /**
-     * Constructor for the Bézier curve animation. This constructor is
-     * meant to be used in the case that you want a constant number
-     * of particles & also multiple bézier curves. It doesn't look pretty at
-     * large distances tho
-     *
-     * @param delay The delay between each particle object render
-     * @param bezierCurves The bézier curves
-     * @param particle The particle to use
-     * @param renderingSteps The amount of rendering steps for the animation
-     */
-    public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves,
-            @NotNull ParticleObject<? extends ParticleObject<?>> particle, int renderingSteps
-    ) {
-        this(delay, bezierCurves, particle, defaultedArray(new int[bezierCurves.length], renderingSteps));
-    }
-
-    /**
-     * Constructor for the Bézier animation. This constructor is
-     * meant to be used in the case that you want a good consistent
-     * looking particle curve as well as better control on their interval
-     * Because of the interval, the amount is dynamic which can cause
-     * performance issues for larger distances(The higher the interval
-     * the fewer particles are rendered, and it is also applied vice versa)
-     *
-     * @param delay The delay between each particle object render
-     * @param bezierCurves The bézier curves
-     * @param particle The particle to use
-     * @param renderingInterval The number of blocks before placing a new render step
-     */
-    public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves,
-            @NotNull ParticleObject<? extends ParticleObject<?>> particle, float[] renderingInterval
-    ) {
-        super(delay, particle, renderingInterval[0]);
-        if (bezierCurves.length == 0) {
-            throw new IllegalArgumentException("Must provide at least one Bézier curve");
-        }
-        if (bezierCurves.length != renderingInterval.length) {
-            throw new IllegalArgumentException("Length of curve and interval arrays do not match");
-        }
-        this.bezierCurves = bezierCurves;
-        this.renderingInterval = renderingInterval;
-        this.renderingSteps = new int[this.bezierCurves.length];
-    }
-
-    /**
-     * Constructor for the bézier animation. This constructor is
-     * meant to be used in the case that you want a constant amount &
-     * of particles also multiple bézier curves. It doesn't look pretty at
-     * large distances tho
-     *
-     * @param delay The delay between each particle object render
-     * @param bezierCurves The bézier curves
-     * @param particle The particle to use
-     * @param renderingSteps The amount of rendering steps for the animation
-     */
-    public BezierCurveAnimator(
-            int delay, @NotNull BezierCurve[] bezierCurves,
-            @NotNull ParticleObject<? extends ParticleObject<?>> particle, int[] renderingSteps
-    ) {
-        super(delay, particle, renderingSteps[0]);
-        if (bezierCurves.length == 0) {
-            throw new IllegalArgumentException("Must provide at least one Bézier curve");
-        }
-        if (bezierCurves.length != renderingSteps.length) {
-            throw new IllegalArgumentException("Length of curve and step arrays do not match");
-        }
-        this.bezierCurves = bezierCurves;
-        this.renderingSteps = renderingSteps;
-        this.renderingInterval = new float[this.renderingSteps.length];
+    private <B extends Builder<B>> BezierCurveAnimator(Builder<B> builder) {
+        super(builder);
+        this.bezierCurves = builder.bezierCurves;
+        this.stepsForCurves = builder.stepsForCurves;
+        this.trimming = builder.trimming;
     }
 
     /**
@@ -171,8 +52,7 @@ public class BezierCurveAnimator extends PathAnimatorBase {
     public BezierCurveAnimator(BezierCurveAnimator animator) {
         super(animator);
         this.bezierCurves = animator.bezierCurves;
-        this.renderingInterval = animator.renderingInterval;
-        this.renderingSteps = animator.renderingSteps;
+        this.stepsForCurves = animator.stepsForCurves;
         this.trimming = animator.trimming;
         this.duringRenderingSteps = animator.duringRenderingSteps;
     }
@@ -203,40 +83,23 @@ public class BezierCurveAnimator extends PathAnimatorBase {
 
     @Override
     public int convertIntervalToSteps() {
-        int steps = 0;
-        for (int i = 0; i < this.bezierCurves.length; i++) {
-            int curveSteps = getCurveSteps(this.bezierCurves[i], this.renderingInterval[i]);
-            steps += curveSteps;
-        }
-        return steps;
-    }
-
-    private int getCurveSteps(BezierCurve bezierCurve, float interval) {
-        // TODO: choose this value better, perhaps based on distance between start/end or start/controls/end?
-        float distance = bezierCurve.length(100);
-        return (int) Math.ceil(distance / interval);
+        return this.stepsForCurves.stream().mapToInt(i -> i).sum();
     }
 
     @Override
     public void beginAnimation(ApelServerRenderer renderer) throws SeqDuplicateException, SeqMissingException {
-        int index = -1;
         int step = -1;
         this.allocateToScheduler();
-        for (BezierCurve bezierCurve : this.bezierCurves) {
-            index++;
-            int curveSteps = this.renderingSteps[index];
-            float renderInterval = this.renderingInterval[index];
-            if (renderInterval != 0.0f) {
-                // Compute steps base on length of curve
-                curveSteps = this.getCurveSteps(bezierCurve, renderInterval);
-            }
+        for (int index = 0; index < this.bezierCurves.size(); index++) {
+            BezierCurve bezierCurve = this.bezierCurves.get(index);
+            int curveSteps = this.stepsForCurves.get(index);
+
             // Interval MUST be the reciprocal of steps so t is in [0, 1].
             float tStep = 1.0f / curveSteps;
             for (float t = 0; t < 1.0f; t += tStep) {
                 step++;
                 Vector3f pos = bezierCurve.compute(t);
-                InterceptData<OnRenderStep> interceptData =
-                        this.doBeforeStep(renderer.getServerWorld(), pos, step);
+                InterceptData<OnRenderStep> interceptData = this.doBeforeStep(renderer.getServerWorld(), pos, step);
                 if (!interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP, true)) {
                     continue;
                 }
@@ -267,5 +130,110 @@ public class BezierCurveAnimator extends PathAnimatorBase {
         interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
+    }
+
+    public static class Builder<B extends Builder<B>> extends PathAnimatorBase.Builder<B, BezierCurveAnimator> {
+        protected List<BezierCurve> bezierCurves = new ArrayList<>();
+        protected List<Integer> stepsForCurves = new ArrayList<>();
+        protected int stepsForAllCurves = 0;
+        protected List<Float> intervalsForCurves = new ArrayList<>();
+        protected float intervalForAllCurves = 0.0f;
+        protected AnimationTrimming<Integer> trimming = new AnimationTrimming<>(0, -1);
+
+        private Builder() {}
+
+        public B bezierCurve(BezierCurve bezierCurve) {
+            this.bezierCurves.add(bezierCurve);
+            return self();
+        }
+
+        public B bezierCurves(List<BezierCurve> bezierCurves) {
+            this.bezierCurves.addAll(bezierCurves);
+            return self();
+        }
+
+        public B stepsForCurve(int stepsForCurve) {
+            this.stepsForCurves.add(stepsForCurve);
+            return self();
+        }
+
+        public B stepsForAllCurves(int steps) {
+            this.stepsForAllCurves = steps;
+            return self();
+        }
+
+        public B stepsForCurves(List<Integer> stepsForCurves) {
+            this.stepsForCurves.addAll(stepsForCurves);
+            return self();
+        }
+
+        public B intervalForCurve(float intervalForCurve) {
+            this.intervalsForCurves.add(intervalForCurve);
+            return self();
+        }
+
+        public B intervalForAllCurves(int interval) {
+            this.intervalForAllCurves = interval;
+            return self();
+        }
+
+        public B intervalsForCurves(List<Float> intervalsForCurves) {
+            this.intervalsForCurves.addAll(intervalsForCurves);
+            return self();
+        }
+
+        public B trimming(AnimationTrimming<Integer> trimming) {
+            this.trimming = trimming;
+            return self();
+        }
+
+        @Override
+        public BezierCurveAnimator build() {
+            if (this.bezierCurves.isEmpty()) {
+                throw new IllegalStateException("Must provide at least one curve");
+            }
+            // If an "all curve" value is provided, it takes priority: interval first, then steps
+            if (this.intervalForAllCurves != 0.0f) {
+                this.intervalsForCurves.clear();
+                for (int i = 0; i < this.bezierCurves.size() - 1; i++) {
+                    this.intervalsForCurves.add(this.intervalForAllCurves);
+                }
+            } else if (this.stepsForAllCurves != 0) {
+                this.stepsForCurves.clear();
+                for (int i = 0; i < this.bezierCurves.size() - 1; i++) {
+                    this.stepsForCurves.add(this.stepsForAllCurves);
+                }
+            }
+            // At this point, either an "all curves" value is provided or individual values for either steps or
+            // intervals must be provided.  At this point, mixing intervals and steps is not allowed.
+            if ((this.stepsForCurves.size() + 1 != this.bezierCurves.size()) && (this.intervalsForCurves.size() + 1 != this.bezierCurves.size())) {
+                throw new IllegalStateException("Must provide steps or intervals for every curve");
+            }
+            for (int i = 0; i < this.bezierCurves.size() - 1; i++) {
+                // Pad the lists so the conversion from interval to steps is straightforward
+                if (this.stepsForCurves.size() == i) {
+                    this.stepsForCurves.add(0);
+                }
+                if (this.intervalsForCurves.size() == i) {
+                    this.intervalsForCurves.add(0.0f);
+                }
+                // Verify that at least one of steps/interval is provided
+                if (this.stepsForCurves.get(i) == 0 && this.intervalsForCurves.get(i) == 0.0f) {
+                    throw new IllegalStateException("Either steps or interval must be positive for curve " + i);
+                }
+                // Interval takes priority, if set.  If not set, then steps must already be set.
+                if (this.intervalsForCurves.get(i) != 0.0f) {
+                    this.stepsForCurves.set(i, this.getCurveSteps(i));
+                }
+            }
+            // TODO: Convert intervals to steps
+            return new BezierCurveAnimator(this);
+        }
+
+        private int getCurveSteps(int index) {
+            // TODO: choose this value better, perhaps based on distance between start/end or start/controls/end?
+            float distance = this.bezierCurves.get(index).length(100);
+            return (int) Math.ceil(distance / this.intervalsForCurves.get(index));
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/LinearAnimator.java
@@ -2,15 +2,15 @@ package net.mcbrincie.apel.lib.animators;
 
 import net.mcbrincie.apel.lib.exceptions.SeqDuplicateException;
 import net.mcbrincie.apel.lib.exceptions.SeqMissingException;
-import net.mcbrincie.apel.lib.objects.ParticleObject;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.AnimationTrimming;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
 import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /** The linear animator. Which is used for linear paths(a.k.a. paths that are drawn as a line). It
@@ -20,139 +20,23 @@ import java.util.Optional;
 */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class LinearAnimator extends PathAnimatorBase {
-    protected Vector3f[] endpoints;
-    protected int[] renderingSteps;
-    protected float[] renderingInterval;
-    protected AnimationTrimming<Integer> trimming = new AnimationTrimming<>(0, -1);
+    protected List<Vector3f> endpoints;
+    protected List<Integer> stepsForSegments;
+    protected AnimationTrimming<Integer> trimming;
 
     protected DrawInterceptor<LinearAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
     public enum OnRenderStep {SHOULD_DRAW_STEP, CURRENT_ENDPOINT, RENDERING_POSITION}
 
-    /** Constructor for the linear animation. This constructor is
-     * meant to be used in the case that you want a constant number
-     * of particles. It doesn't look pretty at large distances tho
-     *
-     * @param delay The delay between each particle object render
-     * @param start The starting position
-     * @param end The ending position
-     * @param particle The particle to use
-     * @param renderingSteps The amount of rendering steps for the animation
-     */
-    public LinearAnimator(
-            int delay, @NotNull Vector3f start, @NotNull Vector3f end,
-            @NotNull ParticleObject<? extends ParticleObject<?>> particle, int renderingSteps
-    ) {
-        this(delay, new Vector3f[]{start, end}, particle, new int[]{renderingSteps});
+    public static <B extends Builder<B>> Builder<B> builder() {
+        return new Builder<>();
     }
 
-    /**
-     * Constructor for the linear animation. This constructor is
-     * meant to be used in the case that you want a good consistent
-     * looking particle line. The amount is dynamic that can cause
-     * performance issues for larger distances (The higher the interval,
-     * the fewer particles are rendered, and it is also applied vice versa)
-     *
-     * @param delay The delay between each particle object render
-     * @param start The starting position
-     * @param end The ending position
-     * @param particle The particle to use
-     * @param renderingInterval The number of blocks before placing a new render step
-     */
-    public LinearAnimator(
-            int delay, @NotNull Vector3f start, @NotNull Vector3f end,
-            @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval
-    ) {
-        this(delay, new Vector3f[]{start, end}, particle, new float[]{renderingInterval});
-    }
-
-    /**
-     * Constructor for the linear animation. This constructor is
-     * meant to be used in the case that you want a good consistent
-     * looking particle line & also want to create multiple endpoints.
-     * Because of the interval, the amount is dynamic that can cause
-     * performance issues for larger distances (The higher the interval
-     * the fewer particles are rendered, and it is also applied vice versa)
-     *
-     * @param delay The delay between each particle object render
-     * @param endpoints The endpoint positions
-     * @param particle The particle to use
-     * @param renderingInterval The distance, in blocks, between rendering steps
-     */
-    public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
-            float renderingInterval
-    ) {
-        // There should be one fewer interval entries than endpoints, since each pair needs an interval
-        this(delay, endpoints, particle, defaultedArray(new float[endpoints.length - 1], renderingInterval));
-    }
-
-    /**
-     * Constructor for the linear animation. This constructor is
-     * meant to be used in the case that you want a constant amount &
-     * of particles also multiple endpoints. It doesn't look pretty at
-     * large distances tho
-     *
-     * @param delay The delay between each particle object render
-     * @param endpoints The endpoint positions
-     * @param particle The particle to use
-     * @param renderingSteps The amount of rendering steps between each pair of endpoints
-     */
-    public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
-            int renderingSteps
-    ) {
-        // There should be one fewer step entries than endpoints since each segment needs steps
-        this(delay, endpoints, particle, defaultedArray(new int[endpoints.length - 1], renderingSteps));
-    }
-
-    /**
-     * Constructor for the linear animation. This constructor is
-     * meant to be used in the case that you want a good consistent
-     * looking particle line as well as better control on their interval
-     * Because of the interval, the amount is dynamic which can cause
-     * performance issues for larger distances(The higher the interval
-     * the fewer particles are rendered, and it is also applied vice versa)
-     *
-     * @param delay The delay between each particle object render
-     * @param endpoints The endpoint positions
-     * @param particle The particle to use
-     * @param renderingInterval The number of blocks before placing a new render step
-     */
-    public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle,
-            float[] renderingInterval
-    ) {
-        super(delay, particle, renderingInterval[0]);
-        if ((renderingInterval.length - 1) == endpoints.length) {
-            throw new IllegalArgumentException("Intervals do not match the endpoints");
-        }
-        this.endpoints = endpoints;
-        this.renderingInterval = renderingInterval;
-        this.renderingSteps = new int[this.renderingInterval.length];
-    }
-
-    /**
-     * Constructor for the linear animation. This constructor is
-     * meant to be used in the case that you want a constant amount &
-     * of particles also multiple endpoints. It doesn't look pretty at
-     * large distances tho
-     *
-     * @param delay The delay between each particle object render
-     * @param endpoints The endpoint positions
-     * @param particle The particle to use
-     * @param renderingSteps The amount of rendering steps for the animation
-     */
-    public LinearAnimator(
-            int delay, @NotNull Vector3f[] endpoints, @NotNull ParticleObject<? extends ParticleObject<?>> particle, int[] renderingSteps
-    ) {
-        super(delay, particle, renderingSteps[0]);
-        if ((renderingSteps.length - 1) == endpoints.length) {
-            throw new IllegalArgumentException("Steps do not match the endpoints");
-        }
-        this.endpoints = endpoints;
-        this.renderingSteps = renderingSteps;
-        this.renderingInterval = new float[this.renderingSteps.length];
+    private <B extends Builder<B>> LinearAnimator(Builder<B> builder) {
+        super(builder);
+        this.endpoints = builder.endpoints;
+        this.stepsForSegments = builder.stepsForSegments;
+        this.trimming = builder.trimming;
     }
 
     /**
@@ -166,74 +50,14 @@ public class LinearAnimator extends PathAnimatorBase {
     public LinearAnimator(LinearAnimator animator) {
         super(animator);
         this.endpoints = animator.endpoints;
-        this.renderingInterval = animator.renderingInterval;
-        this.renderingSteps = animator.renderingSteps;
+        this.stepsForSegments = animator.stepsForSegments;
         this.trimming = animator.trimming;
         this.duringRenderingSteps = animator.duringRenderingSteps;
     }
 
-    /** Gets the distance between the start & end position
-     *
-     * @return The distance between the start and end
-     */
-    public float getDistance() {
-        float sumDistance = 0;
-        for (int i = 0; i < this.endpoints.length - 1; i++) {
-            sumDistance += this.endpoints[i].distance(this.endpoints[i + 1]);
-        }
-        return sumDistance;
-    }
-
-    /** Sets the animation trimming which accepts a start trim or
-     * an ending trim. The trim parts have to be integer values
-     *
-     * @return The animation trimming that is used
-     */
-    public AnimationTrimming<Integer> setTrimming(AnimationTrimming<Integer> trimming) {
-        int startStep = trimming.getStart();
-        int endStep = trimming.getEnd();
-        if (startStep <= 0 || endStep >= this.getRenderingSteps() || startStep >= endStep) {
-            throw new IllegalArgumentException("Invalid animation trimming range");
-        }
-        AnimationTrimming<Integer> prevTrimming = this.trimming;
-        this.trimming = trimming;
-        return prevTrimming;
-    }
-
-    /** Gets the animation trimming that is used
-     *
-     * @return The animation trimming that is used
-     */
-    public AnimationTrimming<Integer> getTrimming() {
-        return this.trimming;
-    }
-
-    /** Sets the endpoint to a new value and returns the previous used value
-     *
-     * @param endpointIndex The endpoint index
-     * @param newEndpoint The new position of the endpoint
-     * @return The previous endpoint
-     */
-    public Vector3f setEndpoint(int endpointIndex, Vector3f newEndpoint) {
-        Vector3f prevEndpoint = this.endpoints[endpointIndex];
-        this.endpoints[endpointIndex] = newEndpoint;
-        return prevEndpoint;
-    }
-
-
     @Override
     public int convertIntervalToSteps() {
-        int steps = 0;
-        for (int i = 0; i < this.endpoints.length - 1; i++) {
-            int segmentSteps = getSegmentSteps(i, this.renderingInterval[i]);
-            steps += segmentSteps;
-        }
-        return steps;
-    }
-
-    private int getSegmentSteps(int segmentIndex, float segmentInterval) {
-        float distance = this.endpoints[segmentIndex].distance(this.endpoints[segmentIndex + 1]);
-        return (int) Math.ceil(distance / segmentInterval);
+        return this.stepsForSegments.stream().mapToInt(i -> i).sum();
     }
 
     @Override
@@ -241,16 +65,13 @@ public class LinearAnimator extends PathAnimatorBase {
         int startStep = this.trimming.getStart();
         int endStep = this.trimming.getEnd();
         this.allocateToScheduler();
+
         int step = -1;
-        for (int segmentIndex = 0; segmentIndex < this.endpoints.length - 1; segmentIndex++) {
-            Vector3f segmentStart = this.endpoints[segmentIndex];
-            Vector3f segmentEnd = this.endpoints[segmentIndex + 1];
-            int segmentSteps = this.renderingSteps[segmentIndex];
-            float segmentInterval = this.renderingInterval[segmentIndex];
-            if (segmentInterval != 0.0f) {
-                // Compute steps based on length of segment
-                segmentSteps = this.getSegmentSteps(segmentIndex, segmentInterval);
-            }
+        for (int segmentIndex = 0; segmentIndex < this.endpoints.size() - 1; segmentIndex++) {
+            Vector3f segmentStart = this.endpoints.get(segmentIndex);
+            Vector3f segmentEnd = this.endpoints.get(segmentIndex + 1);
+            int segmentSteps = this.stepsForSegments.get(segmentIndex);
+
             Vector3f segmentDelta = new Vector3f(segmentEnd).sub(segmentStart).div(segmentSteps);
             for (int i = 0; i < segmentSteps; i++) {
                 step++;
@@ -295,5 +116,136 @@ public class LinearAnimator extends PathAnimatorBase {
         interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
+    }
+
+    public static class Builder<B extends Builder<B>> extends PathAnimatorBase.Builder<B, LinearAnimator> {
+        protected List<Vector3f> endpoints = new ArrayList<>();
+        protected List<Integer> stepsForSegments = new ArrayList<>();
+        protected int stepsForAllSegments;
+        protected List<Float> intervalsForSegments = new ArrayList<>();
+        protected float intervalForAllSegments;
+        protected AnimationTrimming<Integer> trimming = new AnimationTrimming<>(0, -1);
+
+        private Builder() {}
+
+        public B endpoint(Vector3f endpoint) {
+            this.endpoints.add(endpoint);
+            return self();
+        }
+
+        public B endpoints(List<Vector3f> endpoints) {
+            this.endpoints.addAll(endpoints);
+            return self();
+        }
+
+        public B stepsForSegment(int steps) {
+            if (steps < 0) {
+                throw new IllegalArgumentException("Steps must be non-negative");
+            }
+            this.stepsForSegments.add(steps);
+            return self();
+        }
+
+        // Takes priority, if set
+        public B stepsForAllSegments(int steps) {
+            if (steps <= 0) {
+                throw new IllegalArgumentException("Steps for all segments must be positive");
+            }
+            this.stepsForAllSegments = steps;
+            return self();
+        }
+
+        public B stepsForSegments(List<Integer> stepsForSegments) {
+            for (Integer steps : stepsForSegments) {
+                this.stepsForSegment(steps);
+            }
+            return self();
+        }
+
+        public B intervalForSegment(float interval) {
+            if (interval < 0.0f) {
+                throw new IllegalArgumentException("Interval must be non-negative");
+            }
+            this.intervalsForSegments.add(interval);
+            return self();
+        }
+
+        // Takes priority, if set
+        public B intervalForAllSegments(float interval) {
+            if (interval <= 0.0f) {
+                throw new IllegalArgumentException("Interval for all segments must be positive");
+            }
+            this.intervalForAllSegments = interval;
+            return self();
+        }
+
+        public B intervalsForSegments(List<Float> intervalsForSegments) {
+            for (Float interval : intervalsForSegments) {
+                this.intervalForSegment(interval);
+            }
+            return self();
+        }
+
+        public B trimming(AnimationTrimming<Integer> trimming) {
+            if (trimming.getStart() < 0) {
+                throw new IllegalArgumentException("Trim start must be non-negative");
+            }
+            if (trimming.getEnd() < -1) {
+                throw new IllegalArgumentException("Trim end must be -1 (no trim) or non-negative");
+            }
+            if (trimming.getEnd() != -1 && trimming.getStart() >= trimming.getEnd()) {
+                throw new IllegalArgumentException("Trim start must be less than trim end");
+            }
+            this.trimming = trimming;
+            return self();
+        }
+
+        @Override
+        public LinearAnimator build() {
+            if (this.endpoints.size() < 2) {
+                throw new IllegalStateException("Must provide at least two endpoints");
+            }
+            // If an "all segment" value is provided, it takes priority: interval first, then steps
+            if (this.intervalForAllSegments != 0.0f) {
+                this.intervalsForSegments.clear();
+                for (int i = 0; i < this.endpoints.size() - 1; i++) {
+                    this.intervalsForSegments.add(this.intervalForAllSegments);
+                }
+            } else if (this.stepsForAllSegments != 0) {
+                this.stepsForSegments.clear();
+                for (int i = 0; i < this.endpoints.size() - 1; i++) {
+                    this.stepsForSegments.add(this.stepsForAllSegments);
+                }
+            }
+            // At this point, either an "all segments" value is provided or individual values for either steps or
+            // intervals must be provided.  At this point, mixing intervals and steps is not allowed.
+            if ((this.stepsForSegments.size() + 1 != this.endpoints.size()) && (this.intervalsForSegments.size() + 1 != this.endpoints.size())) {
+                throw new IllegalStateException("Must provide steps or intervals for every segment");
+            }
+            for (int i = 0; i < this.endpoints.size() - 1; i++) {
+                // Pad the lists so the conversion from interval to steps is straightforward
+                if (this.stepsForSegments.size() == i) {
+                    this.stepsForSegments.add(0);
+                }
+                if (this.intervalsForSegments.size() == i) {
+                    this.intervalsForSegments.add(0.0f);
+                }
+                // Verify that at least one of steps/interval is provided
+                if (this.stepsForSegments.get(i) == 0 && this.intervalsForSegments.get(i) == 0.0f) {
+                    throw new IllegalStateException("Either steps or interval must be positive for segment " + i);
+                }
+                // Interval takes priority, if set.  If not set, then steps must already be set.
+                if (this.intervalsForSegments.get(i) != 0.0f) {
+                    this.stepsForSegments.set(i, this.getSegmentSteps(i));
+                }
+            }
+            return new LinearAnimator(this);
+        }
+
+        private int getSegmentSteps(int segmentIndex) {
+            float distance = this.endpoints.get(segmentIndex).distance(this.endpoints.get(segmentIndex + 1));
+            return (int) Math.ceil(distance / this.intervalsForSegments.get(segmentIndex));
+        }
+
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/ParallelAnimator.java
@@ -25,88 +25,20 @@ import java.util.Optional;
  */
 @SuppressWarnings("unused")
 public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimator<PathAnimatorBase> {
-    protected List<PathAnimatorBase> animators = new ArrayList<>();
-    protected List<Integer> delays = new ArrayList<>();
+    protected List<PathAnimatorBase> animators;
+    protected List<Integer> animatorDelays;
 
     protected DrawInterceptor<ParallelAnimator, OnRenderPathAnimator> onAnimatorRendering = DrawInterceptor.identity();
 
     public enum OnRenderPathAnimator {PATH_ANIMATOR, SHOULD_RENDER_ANIMATOR, DELAY}
 
-    /** Constructor for the parallel animation. This constructor is
-     * meant to be used in the case that you want to supply a specific
-     * number of path animators in the form of varargs
-     *
-     * @param delay The delay between each particle object render
-     * @param pathAnimators The path animators to append
-     */
-    public ParallelAnimator(int delay, PathAnimatorBase... pathAnimators) {
-        super();
-        this.renderingSteps = pathAnimators.length;
-        this.setDelay(delay);
-        if (pathAnimators.length == 0) {
-            throw new IllegalArgumentException("There must be at least one path animator");
-        }
-        this.animators.addAll(List.of(pathAnimators));
+    public static <B extends Builder<B>> Builder<B> builder() {
+        return new Builder<>();
     }
 
-    /** Constructor for the parallel animation. This constructor is
-     * meant to be used in the case that you have a list of path
-     * animators which you want to supply all of them
-     *
-     * @param delay The delay between each particle object render
-     * @param pathAnimators The path animators to append
-    */
-    public ParallelAnimator(int delay, List<PathAnimatorBase> pathAnimators) {
-        super();
-        this.renderingSteps = pathAnimators.size();
-        this.setDelay(delay);
-        if (pathAnimators.isEmpty()) {
-            throw new IllegalArgumentException("There must be at least one path animator");
-        }
-        this.animators.addAll(pathAnimators);
-    }
-
-    /** Constructor for the parallel animation. This constructor is
-     * meant to be used in the case that you have a list of path
-     * animators and a list of the delays
-     *
-     * @param delay The delays between each particle object render for each particle animator
-     * @param pathAnimators The path animators to append
-     */
-    public ParallelAnimator(List<Integer> delay, List<PathAnimatorBase> pathAnimators) {
-        super();
-        this.delay = -1;
-        this.renderingSteps = pathAnimators.size();
-        if (pathAnimators.isEmpty()) {
-            throw new IllegalArgumentException("There must be at least one path animator");
-        }
-        if (pathAnimators.size() != delay.size()) {
-            throw new IllegalArgumentException("Delays must match the number of path animators");
-        }
-        this.animators.addAll(pathAnimators);
-        this.delays.addAll(delay);
-    }
-
-    /** Constructor for the parallel animation. This constructor is
-     * meant to be used in the case that you want to supply the path
-     * animators in the form of varargs, and in addition you want a
-     * separate delays
-     *
-     * @param delay The delay between each particle object render
-     * @param pathAnimators The path animators to append
-     */
-    public ParallelAnimator(List<Integer> delay, PathAnimatorBase... pathAnimators) {
-        super();
-        this.delay = -1;
-        this.renderingSteps = pathAnimators.length;
-        if (pathAnimators.length == 0) {
-            throw new IllegalArgumentException("There must be at least one path animator");
-        }
-        if (pathAnimators.length != delay.size()) {
-            throw new IllegalArgumentException("Delays must match the number of path animators");
-        }
-        this.animators.addAll(List.of(pathAnimators));
-        this.delays.addAll(delay);
+    private <B extends Builder<B>> ParallelAnimator(Builder<B> builder) {
+        this.animators = builder.childAnimators;
+        this.animatorDelays = builder.childAnimatorDelays;
     }
 
     /** Appends a new child path animator to the collection of the child path animators
@@ -250,5 +182,54 @@ public class ParallelAnimator extends PathAnimatorBase implements TreePathAnimat
         interceptData.addMetadata(OnRenderPathAnimator.SHOULD_RENDER_ANIMATOR, true);
         this.onAnimatorRendering.apply(interceptData, this);
         return interceptData;
+    }
+
+    public static class Builder<B extends Builder<B>> extends PathAnimatorBase.Builder<B, ParallelAnimator> {
+        protected List<PathAnimatorBase> childAnimators = new ArrayList<>();
+        protected List<Integer> childAnimatorDelays = new ArrayList<>();
+
+        private Builder () {}
+
+        public B animator(PathAnimatorBase animator) {
+            this.childAnimators.add(animator);
+            return self();
+        }
+
+        public B animator(PathAnimatorBase animator, int delay) {
+            this.childAnimators.add(animator);
+            this.childAnimatorDelays.add(delay);
+            return self();
+        }
+
+        public B animators(List<PathAnimatorBase> animators) {
+            this.childAnimators.addAll(animators);
+            return self();
+        }
+
+        public B animators(List<PathAnimatorBase> animators, List<Integer> delays) {
+            this.childAnimators.addAll(animators);
+            this.childAnimatorDelays.addAll(delays);
+            return self();
+        }
+
+        @Override
+        public ParallelAnimator build() {
+            if (this.delay < 0) {
+                throw new IllegalStateException("Initial delay must be non-negative");
+            }
+            for (int i = 0; i < this.childAnimators.size(); i++) {
+                if (this.childAnimators.get(i) == null) {
+                    throw new NullPointerException("Child Animator cannot be null");
+                }
+                // Pad the list of delays, so it's equal in length
+                if (this.childAnimatorDelays.size() == i) {
+                    this.childAnimatorDelays.add(0);
+                }
+                if (this.childAnimatorDelays.get(i) < 0) {
+                    throw new IllegalStateException("Child animator delays must be non-negative");
+                }
+            }
+            return new ParallelAnimator(this);
+        }
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -90,7 +90,9 @@ public abstract class PathAnimatorBase {
      *  sequence. The method does that for your convenience
      */
     public void allocateToScheduler() {
-        if (this.delay == 0) return;
+        if (this.delay == 0) {
+            return;
+        }
         Apel.SCHEDULER.allocateNewSequence(this);
     }
 
@@ -303,5 +305,45 @@ public abstract class PathAnimatorBase {
     protected static float[] defaultedArray(float[] array, float defaultValue) {
         Arrays.fill(array, defaultValue);
         return array;
+    }
+
+    public static abstract class Builder<B extends Builder<B, T>, T extends PathAnimatorBase> {
+        protected ParticleObject<? extends ParticleObject<?>> particleObject;
+        protected int delay = 1;
+        protected int processingSpeed = 1;
+        protected int renderingSteps;
+        protected float renderingInterval;
+
+        @SuppressWarnings({"unchecked"})
+        public final B self() {
+            return (B) this;
+        }
+
+        public final B particleObject(ParticleObject<? extends ParticleObject<?>> particleObject) {
+            this.particleObject = particleObject;
+            return self();
+        }
+
+        public final B delay(int delay) {
+            this.delay = delay;
+            return self();
+        }
+
+        public final B processingSpeed(int processingSpeed) {
+            this.processingSpeed = processingSpeed;
+            return self();
+        }
+
+        public final B renderingSteps(int renderingSteps) {
+            this.renderingSteps = renderingSteps;
+            return self();
+        }
+
+        public final B renderingInterval(float renderingInterval) {
+            this.renderingInterval = renderingInterval;
+            return self();
+        }
+
+        public abstract T build();
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PathAnimatorBase.java
@@ -32,40 +32,16 @@ public abstract class PathAnimatorBase {
 
     protected static TrigTable trigTable = Apel.TRIG_TABLE;
 
-    /**
-     * Constructor for the path animator. This constructor is meant to be used when you want a
-     * constant amount of rendering steps. It is worth pointing out that this won't look
-     * pleasant in the eyes at larger distances. For that, it is recommended to look into:
-     *
-     * @param delay          The delay per rendering step
-     * @param particleObject The particle object to use
-     * @param renderingSteps The rendering steps to use
-     * @see PathAnimatorBase#PathAnimatorBase(int, ParticleObject, float)
-    */
-    public PathAnimatorBase(int delay, ParticleObject<? extends ParticleObject<?>> particleObject, int renderingSteps) {
-        this.setDelay(delay);
-        this.setParticleObject(particleObject);
-        this.setRenderingSteps(renderingSteps);
+    protected <B extends Builder<B, T>, T extends PathAnimatorBase> PathAnimatorBase(Builder<B, T> builder) {
+        this.particleObject = builder.particleObject;
+        this.delay = builder.delay;
+        this.processingSpeed = builder.processingSpeed;
+        this.renderingSteps = builder.renderingSteps;
+        this.renderingInterval = builder.renderingInterval;
     }
 
     /** This is an empty constructor meant as a placeholder */
     public PathAnimatorBase() {
-    }
-
-    /**
-     * Constructor for the path animator. This constructor is meant to be used when you want a
-     * consistent amount of rendering steps no matter the distance. It is worth pointing out that
-     * there will be performance overhead for large distances. To minimize, it is recommended to look into:
-     *
-     * @param delay             The delay per rendering step
-     * @param particle          The particle object to use
-     * @param renderingInterval The rendering interval to use, which is how many blocks per new rendering step
-     * @see PathAnimatorBase#PathAnimatorBase(int, ParticleObject, int)
-     */
-    public PathAnimatorBase(int delay, @NotNull ParticleObject<? extends ParticleObject<?>> particle, float renderingInterval) {
-        this.setDelay(delay);
-        this.setParticleObject(particle);
-        this.setRenderingInterval(renderingInterval);
     }
 
     /**

--- a/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
+++ b/src/main/java/net/mcbrincie/apel/lib/animators/PointAnimator.java
@@ -2,12 +2,10 @@ package net.mcbrincie.apel.lib.animators;
 
 import net.mcbrincie.apel.lib.exceptions.SeqDuplicateException;
 import net.mcbrincie.apel.lib.exceptions.SeqMissingException;
-import net.mcbrincie.apel.lib.objects.ParticleObject;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.interceptor.DrawInterceptor;
 import net.mcbrincie.apel.lib.util.interceptor.InterceptData;
 import net.minecraft.server.world.ServerWorld;
-import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
 import java.util.Optional;
@@ -19,41 +17,16 @@ import java.util.Optional;
 */
 @SuppressWarnings("unused")
 public class PointAnimator extends PathAnimatorBase {
-    protected Vector3f origin;
+    protected Vector3f point;
     protected DrawInterceptor<PointAnimator, OnRenderStep> duringRenderingSteps = DrawInterceptor.identity();
 
     public enum OnRenderStep {SHOULD_DRAW_STEP}
 
-    /** Constructor for the point animator. It basically animates the object in a certain place.
-     * The place is called the origin, which is only a point (hence the point animator)
-     *
-     * @param delay The delay per rendering step
-     * @param particle The particle object to use
-     * @param renderingSteps The rendering steps to use
-    */
-    public PointAnimator(int delay, @NotNull ParticleObject<? extends ParticleObject<?>> particle, Vector3f origin,
-                         int renderingSteps) {
-        super(delay, particle, renderingSteps);
-        this.origin = origin;
-    }
+    public static <B extends Builder<B>> Builder<B> builder() { return new Builder<>(); }
 
-    /** Gets the origin point. Which is where the particle animation plays at
-     *
-     * @return The origin point(that is stationary)
-    */
-    public Vector3f getOrigin() {
-        return this.origin;
-    }
-
-    /** Sets the origin point. Which is where the particle animation plays at. Returns
-     * the previous origin point that was used
-     *
-     * @return The previous origin point used
-    */
-    public Vector3f setOrigin(Vector3f origin) {
-        Vector3f prevOrigin = this.origin;
-        this.origin = origin;
-        return prevOrigin;
+    private <B extends Builder<B>> PointAnimator(Builder<B> builder) {
+        super(builder);
+        this.point = builder.point;
     }
 
     /**
@@ -63,11 +36,30 @@ public class PointAnimator extends PathAnimatorBase {
      * of their visibility (this means protected & private params are copied)
      *
      * @param animator The animator to copy from
-    */
+     */
     public PointAnimator(PointAnimator animator) {
         super(animator);
-        this.origin = animator.origin;
+        this.point = animator.point;
         this.duringRenderingSteps = animator.duringRenderingSteps;
+    }
+
+    /** Gets the origin point. Which is where the particle animation plays at
+     *
+     * @return The origin point(that is stationary)
+    */
+    public Vector3f getPoint() {
+        return this.point;
+    }
+
+    /** Sets the origin point. Which is where the particle animation plays at. Returns
+     * the previous origin point that was used
+     *
+     * @return The previous origin point used
+    */
+    public Vector3f setPoint(Vector3f point) {
+        Vector3f prevPoint = this.point;
+        this.point = point;
+        return prevPoint;
     }
 
     @Override
@@ -83,7 +75,7 @@ public class PointAnimator extends PathAnimatorBase {
             if (!interceptData.getMetadata(OnRenderStep.SHOULD_DRAW_STEP, true)) {
                 continue;
             }
-            this.handleDrawingStep(renderer, i, this.origin);
+            this.handleDrawingStep(renderer, i, this.point);
         }
     }
 
@@ -104,5 +96,21 @@ public class PointAnimator extends PathAnimatorBase {
         interceptData.addMetadata(OnRenderStep.SHOULD_DRAW_STEP, true);
         this.duringRenderingSteps.apply(interceptData, this);
         return interceptData;
+    }
+
+    public static class Builder<B extends Builder<B>> extends PathAnimatorBase.Builder<B, PointAnimator> {
+        protected Vector3f point = new Vector3f();
+
+        private Builder() {}
+
+        public B point(Vector3f point) {
+            this.point = point;
+            return self();
+        }
+
+        @Override
+        public PointAnimator build() {
+            return new PointAnimator(this);
+        }
     }
 }

--- a/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/animators/LinearAnimatorTest.java
@@ -4,6 +4,8 @@ import net.mcbrincie.apel.lib.objects.ParticlePoint;
 import org.joml.Vector3f;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LinearAnimatorTest {
@@ -11,25 +13,11 @@ class LinearAnimatorTest {
     private static final ParticlePoint POINT_WITH_NULL_PARTICLE = ParticlePoint.builder().particleEffect(null).build();
 
     @Test
-    void testGetDistance() {
-        // Given a LinearAnimator with a rendering interval
-        LinearAnimator linearAnimator = new LinearAnimator(1, new Vector3f[]{
-                new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0),
-        }, POINT_WITH_NULL_PARTICLE, .04f);
-
-        // When the distance is computed
-        float distance = linearAnimator.getDistance();
-
-        // Then it is 57: (10 to -10) + (-10 to 9) + (9 to -9), or 20 + 19 + 18 == 57.
-        assertEquals(57f, distance);
-    }
-
-    @Test
     void testConvertIntervalToSteps() {
         // Given a LinearAnimator with a rendering interval
-        LinearAnimator linearAnimator = new LinearAnimator(1, new Vector3f[]{
-                new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0),
-        }, POINT_WITH_NULL_PARTICLE, .04f);
+        LinearAnimator linearAnimator = LinearAnimator.builder().delay(1).endpoints(
+                List.of(new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0)))
+                .particleObject(POINT_WITH_NULL_PARTICLE).intervalForAllSegments(.04f).build();
 
         // When the distance is computed
         int steps = linearAnimator.convertIntervalToSteps();
@@ -41,9 +29,9 @@ class LinearAnimatorTest {
     @Test
     void testConvertIntervalToStepsWithUniqueIntervals() {
         // Given a LinearAnimator with a rendering interval
-        LinearAnimator linearAnimator = new LinearAnimator(1, new Vector3f[]{
-                new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0),
-        }, POINT_WITH_NULL_PARTICLE, new float[]{.04f, .1f, .5f});
+        LinearAnimator linearAnimator = LinearAnimator.builder().delay(1).endpoints(
+                        List.of(new Vector3f(10, 0, 0), new Vector3f(-10, 0, 0), new Vector3f(9, 0, 0), new Vector3f(-9, 0, 0)))
+                .particleObject(POINT_WITH_NULL_PARTICLE).intervalsForSegments(List.of(.04f, .1f, .5f)).build();
 
         // When the distance is computed
         int steps = linearAnimator.convertIntervalToSteps();


### PR DESCRIPTION
Fixes https://github.com/GitBrincie212/Apel-Mod/issues/36

Convert all animators to use builders for construction.  They often have even more properties than particle objects, so this should be a greater benefit here.  I think these are at a good starting point, but they could benefit from some usage and subsequent feedback.

Details:
* PathAnimatorBase - mimics ParticleObject in being generic, subclassed, mostly final, etc.
* PointAnimator - change `origin` to `point` for clarity.
* Circular/Ellipse - Straightforward conversion.  Should consider whether `revolutions`, `trimming`, etc. can be changed, since they're directly used in scheduling steps, and this all happens almost immediately when calling `beginAnimation`.
* Bezier Curve - uses `List` to build the internal curve collection, this is easier than arrays.  Also, trims on `t` value instead of steps, since using `renderingInterval` may result in an unknown number of steps.
* Linear - mimics Bezier changes.  Also allows for steps _or_ interval per segment.  It is up to the builder user to set these correctly.  This is one area where some trial/usage is needed to helped solidify the API.  I like the idea of steps or interval, need to refine the API, I think.
* Clean up unused methods/constructors in all animators.
* Parallel/Sequential - give each child animator a configurable delay.  In Parallel, this is relative to the ParallelAnimator starting, in Seqeuential, this is relative to the previous child animator.  These delays are before any child animator frame delays are processed.

If there are trivial fixes/changes, happy to incorporate here.  If there is more extensive change/feedback, probably best in a follow-up.  These have all been tested, and they do work the way they are as far as I can tell.