### PR TITLE
Cuboid standardization

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -163,39 +163,40 @@ public class ParticleCuboid extends ParticleObject<ParticleCuboid> {
         float width = size.x / 2f;
         float height = size.y / 2f;
         float depth = size.z / 2f;
-        // Rotation
-        Quaternionfc quaternion =
-                new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
-        // Translation
-        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
         // Compute the cuboid vertices
-        Vector3f vertex0 = this.rigidTransformation(width, -height, -depth, quaternion, objectDrawPos);
-        Vector3f vertex1 = this.rigidTransformation(width, -height, depth, quaternion, objectDrawPos);
-        Vector3f vertex2 = this.rigidTransformation(-width, -height, depth, quaternion, objectDrawPos);
-        Vector3f vertex3 = this.rigidTransformation(-width, -height, -depth, quaternion, objectDrawPos);
-        Vector3f vertex4 = this.rigidTransformation(width, height, -depth, quaternion, objectDrawPos);
-        Vector3f vertex5 = this.rigidTransformation(width, height, depth, quaternion, objectDrawPos);
-        Vector3f vertex6 = this.rigidTransformation(-width, height, depth, quaternion, objectDrawPos);
-        Vector3f vertex7 = this.rigidTransformation(-width, height, -depth, quaternion, objectDrawPos);
+        Vector3f vertex0 = new Vector3f(width, -height, -depth);
+        Vector3f vertex1 = new Vector3f(width, -height, depth);
+        Vector3f vertex2 = new Vector3f(-width, -height, depth);
+        Vector3f vertex3 = new Vector3f(-width, -height, -depth);
+        Vector3f vertex4 = new Vector3f(width, height, -depth);
+        Vector3f vertex5 = new Vector3f(width, height, depth);
+        Vector3f vertex6 = new Vector3f(-width, height, depth);
+        Vector3f vertex7 = new Vector3f(-width, height, -depth);
 
         Vector3f[] vertices = {vertex0, vertex1, vertex2, vertex3, vertex4, vertex5, vertex6, vertex7};
         drawContext.addMetadata(VERTICES, vertices);
     }
 
     @Override
-    public void draw(ApelServerRenderer renderer, DrawContext data) {
-        Vector3f[] vertices = data.getMetadata(VERTICES);
+    public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
+        // Rotation
+        Quaternionfc quaternion =
+                new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
+        // Translation
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
+        // Scaled and re-positioned vertices
+        Vector3f[] vertices = drawContext.getMetadata(VERTICES);
 
-        Vector3f vertex0 = vertices[0];
-        Vector3f vertex1 = vertices[1];
-        Vector3f vertex2 = vertices[2];
-        Vector3f vertex3 = vertices[3];
-        Vector3f vertex4 = vertices[4];
-        Vector3f vertex5 = vertices[5];
-        Vector3f vertex6 = vertices[6];
-        Vector3f vertex7 = vertices[7];
+        Vector3f vertex0 = this.rigidTransformation(vertices[0], quaternion, objectDrawPos);
+        Vector3f vertex1 = this.rigidTransformation(vertices[1], quaternion, objectDrawPos);
+        Vector3f vertex2 = this.rigidTransformation(vertices[2], quaternion, objectDrawPos);
+        Vector3f vertex3 = this.rigidTransformation(vertices[3], quaternion, objectDrawPos);
+        Vector3f vertex4 = this.rigidTransformation(vertices[4], quaternion, objectDrawPos);
+        Vector3f vertex5 = this.rigidTransformation(vertices[5], quaternion, objectDrawPos);
+        Vector3f vertex6 = this.rigidTransformation(vertices[6], quaternion, objectDrawPos);
+        Vector3f vertex7 = this.rigidTransformation(vertices[7], quaternion, objectDrawPos);
 
-        int step = data.getCurrentStep();
+        int step = drawContext.getCurrentStep();
         int bottomFaceAmount = this.amount.x;
         int topFaceAmount = this.amount.y;
         int verticalBarsAmount = this.amount.z;

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
@@ -337,7 +337,7 @@ public abstract class ParticleObject<T extends ParticleObject<T>> {
          * Set the particle amount on the builder.  This method is not cumulative; repeated calls will overwrite the
          * value.
          */
-        public B amount(int amount) {
+        public final B amount(int amount) {
             this.amount = amount;
             return self();
         }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
@@ -271,22 +271,6 @@ public abstract class ParticleObject<T extends ParticleObject<T>> {
     }
 
     /**
-     * Transforms the point at {@code (x, y, z)} according to the {@code quaternion} and {@code translation}.
-     *
-     * <p>Does not modify the {@code quaternion} or {@code translation}.
-     *
-     * @param x The x-coordinate of the point to transform
-     * @param y The y-coordinate of the point to transform
-     * @param z The z-coordinate of the point to transform
-     * @param quaternion The rotation to apply
-     * @param translation The translation to apply
-     * @return The transformed point
-     */
-    protected final Vector3f rigidTransformation(float x, float y, float z, Quaternionfc quaternion, Vector3f translation) {
-        return new Vector3f(x, y, z).rotate(quaternion).add(translation);
-    }
-
-    /**
      * Transforms a copy of the point at {@code position} according to the {@code quaternion} and {@code translation}.
      *
      * <p>Does not modify the {@code quaternion} or {@code translation}.

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCuboidTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleCuboidTest.java
@@ -17,7 +17,7 @@ class ParticleCuboidTest {
         ParticleCuboid cuboid = builder.build();
 
         // Then the amount is a vector with components equal to the integer
-        assertEquals(new Vector3i(amount), cuboid.getAmount(ParticleCuboid.AreaLabel.ALL_FACES));
+        assertEquals(new Vector3i(amount), cuboid.getAmounts());
     }
 
 }


### PR DESCRIPTION
ParticleCuboid amount handling has long had a "this isn't done right, needs to be better" comment on it, so this addresses that.  It adds specific methods to get and set the amounts on the cuboid.  It also changes the relationship between the vector components and which lines are affected.  I think it's most likely that the lines parallel to x-axis will all need the same amount, and similarly for y and z-axes.

Also, the rotation and transformation of the vertices should be after the `before` interceptor, so the interceptor can modify the points in a manner similar to other line-based particle objects.  This does that, too.