### PR TITLE
Improve Model calculations and thread-safety

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/util/interceptor/DrawContext.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/interceptor/DrawContext.java
@@ -131,10 +131,6 @@ public class DrawContext {
         return new Key<>(name) { };
     }
 
-    public static Key<List<Pair<Vector3f, Vector3f>>> vector3fListPairKey(String name) {
-        return new Key<>(name) { };
-    }
-
     @SuppressWarnings("unused")
     public static Key<Float> floatKey(String name) {
         return new Key<>(name) { };

--- a/src/main/java/net/mcbrincie/apel/lib/util/models/FbxParser.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/models/FbxParser.java
@@ -2,7 +2,9 @@ package net.mcbrincie.apel.lib.util.models;
 
 import java.io.File;
 
-public class FbxParser {
-    public void parseFbxFile(ModelParserManager manager, File model_file) {
+public class FbxParser implements ModelParser {
+    @Override
+    public ObjModel parse(File file) {
+        return null;
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/util/models/GltfParser.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/models/GltfParser.java
@@ -2,7 +2,9 @@ package net.mcbrincie.apel.lib.util.models;
 
 import java.io.File;
 
-public class GltfParser {
-    public void parseGltfFile(ModelParserManager manager, File model_file) {
+public class GltfParser implements ModelParser {
+    @Override
+    public ObjModel parse(File file) {
+        return null;
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/util/models/ModelParser.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/models/ModelParser.java
@@ -1,0 +1,7 @@
+package net.mcbrincie.apel.lib.util.models;
+
+import java.io.File;
+
+public interface ModelParser {
+    ObjModel parse(File file);
+}

--- a/src/main/java/net/mcbrincie/apel/lib/util/models/ModelParserManager.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/models/ModelParserManager.java
@@ -1,50 +1,31 @@
 package net.mcbrincie.apel.lib.util.models;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
-import org.joml.Vector2f;
-import org.joml.Vector3f;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
-public class ModelParserManager {
-    public List<Vector3f> vertices = new ArrayList<>();
-    public List<Vector2f> textureVertices = new ArrayList<>();
-    public List<Vector3f> normalVertices = new ArrayList<>();
-    public List<List<Vector3f>> drawableLines = new ArrayList<>();
-    public List<FaceToken> drawableFaces = new ArrayList<>();
+public class ModelParserManager implements ModelParser {
+    private static final ImmutableMap<String, ModelParser> PARSERS_BY_EXT = parsersMap();
 
-    private static final ObjParser objParser = new ObjParser();
-    private static final GltfParser gltfParser = new GltfParser();
-    private static final FbxParser fbxParser = new FbxParser();
-
-    public static class FaceToken {
-        public Vector3f[] vertices;
-        public Vector2f[] textureVertices;
-        public Vector3f[] normalVertices;
-
-        public FaceToken(
-                Vector3f[] vertex_tokens,
-                Vector2f[] texture_vertex_tokens,
-                Vector3f[] normal_vertex_tokens
-        ) {
-            this.vertices = vertex_tokens;
-            this.textureVertices = texture_vertex_tokens;
-            this.normalVertices = normal_vertex_tokens;
-        }
+    private static ImmutableMap<String, ModelParser> parsersMap() {
+        ImmutableMap.Builder<String, ModelParser> builder = ImmutableMap.builder();
+        builder.put("obj", new ObjParser());
+        builder.put("fbx", new FbxParser());
+        builder.put("gltf", new GltfParser());
+        return builder.build();
     }
 
-    public void parseFile(File file) {
+    @Override
+    public ObjModel parse(File file) {
         if (!file.isFile()) {
             throw new IllegalArgumentException("The supplied file object is not a file");
         }
         String extension = Files.getFileExtension(file.getPath());
-        switch (extension) {
-            case "obj" -> objParser.parseObjFile(this, file);
-            case "gltf" -> gltfParser.parseGltfFile(this, file);
-            case "fbx" -> fbxParser.parseFbxFile(this, file);
-            default -> throw new UnsupportedOperationException("The parser doesn't support this 3D model file");
+        ModelParser parser = PARSERS_BY_EXT.get(extension);
+        if (parser == null) {
+            throw new UnsupportedOperationException("The parser doesn't support this 3D model file");
         }
+        return parser.parse(file);
     }
 }

--- a/src/main/java/net/mcbrincie/apel/lib/util/models/ObjModel.java
+++ b/src/main/java/net/mcbrincie/apel/lib/util/models/ObjModel.java
@@ -1,0 +1,21 @@
+package net.mcbrincie.apel.lib.util.models;
+
+import com.google.common.collect.ImmutableList;
+import org.joml.Vector2f;
+import org.joml.Vector3f;
+
+import java.util.List;
+
+/**
+ * Represents a read-only *.obj model
+ */
+public record ObjModel(ImmutableList<Face> faces, ImmutableList<PolyLine> polyLines) {
+    public record Vertex(Vector3f position, Vector2f textureCoordinates, Vector3f normal) {
+    }
+
+    public record Face(ImmutableList<Vertex> vertices) {
+    }
+
+    public record PolyLine(ImmutableList<Vector3f> positions) {
+    }
+}


### PR DESCRIPTION
Clean up model, add builder, improve parser so it's thread-safe and produces read-only object models.

Tested with the ender dragon model scaled and rotating.