### PR TITLE
Fix position cache "leak" caused by unique lines

### DIFF
--- a/src/main/java/net/mcbrincie/apel/client/ApelFramePayloadHandler.java
+++ b/src/main/java/net/mcbrincie/apel/client/ApelFramePayloadHandler.java
@@ -35,8 +35,8 @@ final class ApelFramePayloadHandler implements ClientPlayNetworking.PlayPayloadH
 
                     case ApelRenderer.Particle(Vector3f pos) -> renderer.drawParticle(particleEffect, 0, pos);
 
-                    case ApelRenderer.Line(Vector3f start, Vector3f end, int amount) ->
-                            renderer.drawLine(particleEffect, 0, start, end, amount);
+                    case ApelRenderer.Line(Vector3f drawPos, Vector3f start, Vector3f end, Vector3f rotation, int amount) ->
+                            renderer.drawLine(particleEffect, 0, drawPos, start, end, rotation, amount);
 
                     case ApelRenderer.Ellipse(
                             Vector3f center, float radius, float stretch, Vector3f rotation, int amount

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleCuboid.java
@@ -1,8 +1,6 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import org.joml.Quaternionf;
-import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
 
@@ -12,8 +10,8 @@ import org.joml.Vector3i;
  * <p>
  * <strong>Note: </strong>ParticleCuboid does not respect the {@link #getAmount()} method inherited from ParticleObject.
  * Instead, it contains amounts for the edges parallel to each axis using {@link #setAmounts(Vector3i)}.  If all edges
- * should have the same number of of particles, then {@link #setAmount(int)} may be used.  The builder allows both
- * methods as well.
+ * should have the same number of particles, then {@link #setAmount(int)} may be used.  The builder allows both methods
+ * as well.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ParticleCuboid extends ParticleObject<ParticleCuboid> {
@@ -166,22 +164,18 @@ public class ParticleCuboid extends ParticleObject<ParticleCuboid> {
 
     @Override
     public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
-        // Rotation
-        Quaternionfc quaternion =
-                new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
-        // Translation
         Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
         // Scaled and re-positioned vertices
         Vector3f[] vertices = drawContext.getMetadata(VERTICES);
 
-        Vector3f vertex0 = this.rigidTransformation(vertices[0], quaternion, objectDrawPos);
-        Vector3f vertex1 = this.rigidTransformation(vertices[1], quaternion, objectDrawPos);
-        Vector3f vertex2 = this.rigidTransformation(vertices[2], quaternion, objectDrawPos);
-        Vector3f vertex3 = this.rigidTransformation(vertices[3], quaternion, objectDrawPos);
-        Vector3f vertex4 = this.rigidTransformation(vertices[4], quaternion, objectDrawPos);
-        Vector3f vertex5 = this.rigidTransformation(vertices[5], quaternion, objectDrawPos);
-        Vector3f vertex6 = this.rigidTransformation(vertices[6], quaternion, objectDrawPos);
-        Vector3f vertex7 = this.rigidTransformation(vertices[7], quaternion, objectDrawPos);
+        Vector3f vertex0 = vertices[0];
+        Vector3f vertex1 = vertices[1];
+        Vector3f vertex2 = vertices[2];
+        Vector3f vertex3 = vertices[3];
+        Vector3f vertex4 = vertices[4];
+        Vector3f vertex5 = vertices[5];
+        Vector3f vertex6 = vertices[6];
+        Vector3f vertex7 = vertices[7];
 
         int step = drawContext.getCurrentStep();
         int xAmount = this.amounts.x;
@@ -189,22 +183,22 @@ public class ParticleCuboid extends ParticleObject<ParticleCuboid> {
         int zAmount = this.amounts.z;
 
         // Bottom Face
-        renderer.drawLine(this.particleEffect, step, vertex0, vertex1, zAmount);
-        renderer.drawLine(this.particleEffect, step, vertex1, vertex2, xAmount);
-        renderer.drawLine(this.particleEffect, step, vertex2, vertex3, zAmount);
-        renderer.drawLine(this.particleEffect, step, vertex3, vertex0, xAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex0, vertex1, this.rotation, zAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex1, vertex2, this.rotation, xAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex2, vertex3, this.rotation, zAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex3, vertex0, this.rotation, xAmount);
 
         // Top Face
-        renderer.drawLine(this.particleEffect, step, vertex4, vertex5, zAmount);
-        renderer.drawLine(this.particleEffect, step, vertex5, vertex6, xAmount);
-        renderer.drawLine(this.particleEffect, step, vertex6, vertex7, zAmount);
-        renderer.drawLine(this.particleEffect, step, vertex7, vertex4, xAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex4, vertex5, this.rotation, zAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex5, vertex6, this.rotation, xAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex6, vertex7, this.rotation, zAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex7, vertex4, this.rotation, xAmount);
 
         // Vertical
-        renderer.drawLine(this.particleEffect, step, vertex0, vertex4, yAmount);
-        renderer.drawLine(this.particleEffect, step, vertex1, vertex5, yAmount);
-        renderer.drawLine(this.particleEffect, step, vertex2, vertex6, yAmount);
-        renderer.drawLine(this.particleEffect, step, vertex3, vertex7, yAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex0, vertex4, this.rotation, yAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex1, vertex5, this.rotation, yAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex2, vertex6, this.rotation, yAmount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, vertex3, vertex7, this.rotation, yAmount);
     }
 
     public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleCuboid> {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleLine.java
@@ -1,8 +1,6 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import org.joml.Quaternionf;
-import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 
 /**
@@ -98,16 +96,8 @@ public class ParticleLine extends ParticleObject<ParticleLine> {
 
     @Override
     public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
-        // Rotation
-        Quaternionfc quaternion =
-                new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
-        // Translation
         Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
-
-        Vector3f v1 = this.rigidTransformation(this.start, quaternion, objectDrawPos);
-        Vector3f v2 = this.rigidTransformation(this.end, quaternion, objectDrawPos);
-
-        renderer.drawLine(this.particleEffect, drawContext.getCurrentStep(), v1, v2, this.amount);
+        renderer.drawLine(this.particleEffect, drawContext.getCurrentStep(), objectDrawPos, this.start, this.end, this.rotation, this.amount);
     }
 
     public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleLine> {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleModel.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleModel.java
@@ -2,16 +2,12 @@ package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.mcbrincie.apel.lib.util.models.ModelParserManager;
-import net.mcbrincie.apel.lib.util.models.ObjParser;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.particle.ParticleTypes;
-import org.joml.Quaternionf;
-import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 import oshi.util.tuples.Pair;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 
 
@@ -103,17 +99,14 @@ public class ParticleModel extends ParticleObject<ParticleModel> {
 
     @Override
     public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
-        Quaternionfc quaternion = new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
         Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
         for (Pair<Vector3f, Vector3f> vertexPair : this.positions.keySet()) {
             ParticleEffect currParticle = this.positions.get(vertexPair);
             Vector3f vertex1 = new Vector3f(vertexPair.getA()).mul(this.scale);
             Vector3f vertex2 = new Vector3f(vertexPair.getB()).mul(this.scale);
-            vertex1 = this.rigidTransformation(vertex1, quaternion, objectDrawPos);
-            vertex2 = this.rigidTransformation(vertex2, quaternion, objectDrawPos);
             renderer.drawLine(
-                    currParticle, drawContext.getCurrentStep(),
-                    vertex1, vertex2, 10
+                    currParticle, drawContext.getCurrentStep(), objectDrawPos,
+                    vertex1, vertex2, this.rotation, 10
             );
         }
     }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleObject.java
@@ -3,7 +3,6 @@ package net.mcbrincie.apel.lib.objects;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
-import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 
 import java.util.Optional;
@@ -268,20 +267,6 @@ public abstract class ParticleObject<T extends ParticleObject<T>> {
      */
     protected void prepareContext(DrawContext drawContext) {
         // Default implementation does nothing
-    }
-
-    /**
-     * Transforms a copy of the point at {@code position} according to the {@code quaternion} and {@code translation}.
-     *
-     * <p>Does not modify the {@code quaternion} or {@code translation}.
-     *
-     * @param position The x-coordinate of the point to transform.
-     * @param quaternion The rotation to apply
-     * @param translation The translation to apply
-     * @return The transformed point in a new Vector3f
-     */
-    protected final Vector3f rigidTransformation(Vector3f position, Quaternionfc quaternion, Vector3f translation) {
-        return new Vector3f(position).rotate(quaternion).add(translation);
     }
 
     /**

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePolygon.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticlePolygon.java
@@ -3,7 +3,6 @@ package net.mcbrincie.apel.lib.objects;
 import net.mcbrincie.apel.Apel;
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
 import org.jetbrains.annotations.NotNull;
-import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import java.util.HashMap;
@@ -100,15 +99,15 @@ public class ParticlePolygon extends ParticleObject<ParticlePolygon> {
     @Override
     public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
         Vector3f[] vertices = getRawVertices();
-        // Defensive copy
         Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
-        this.computeVertices(vertices, objectDrawPos);
 
         // Divide the particles evenly among sides
         int particlesPerLine = this.amount / this.sides;
         for (int i = 0; i < vertices.length - 1; i++) {
             renderer.drawLine(
-                    this.particleEffect, drawContext.getCurrentStep(), vertices[i], vertices[i + 1], particlesPerLine);
+                    this.particleEffect, drawContext.getCurrentStep(), objectDrawPos, vertices[i], vertices[i + 1],
+                    this.rotation, particlesPerLine
+            );
         }
     }
 
@@ -137,15 +136,6 @@ public class ParticlePolygon extends ParticleObject<ParticlePolygon> {
             verticesCopy[i] = new Vector3f(cachedVertices[i]);
         }
         return verticesCopy;
-    }
-
-    private void computeVertices(Vector3f[] vertices, Vector3f center) {
-        Quaternionf quaternion = new Quaternionf().rotateZ(this.rotation.z)
-                                                  .rotateY(this.rotation.y)
-                                                  .rotateX(this.rotation.x);
-        for (Vector3f vertex : vertices) {
-            vertex.rotate(quaternion).add(center);
-        }
     }
 
     public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticlePolygon> {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleQuad.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleQuad.java
@@ -1,8 +1,6 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import org.joml.Quaternionf;
-import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 
 
@@ -25,12 +23,6 @@ public class ParticleQuad extends ParticleObject<ParticleQuad> {
     protected Vector3f vertex2;
     protected Vector3f vertex3;
     protected Vector3f vertex4;
-
-    /** This data is used after calculations (it contains the modified four vertices) */
-    public static final DrawContext.Key<Vector3f> VERTEX_1 = DrawContext.vector3fKey("vertex1");
-    public static final DrawContext.Key<Vector3f> VERTEX_2 = DrawContext.vector3fKey("vertex2");
-    public static final DrawContext.Key<Vector3f> VERTEX_3 = DrawContext.vector3fKey("vertex3");
-    public static final DrawContext.Key<Vector3f> VERTEX_4 = DrawContext.vector3fKey("vertex4");
 
     public static Builder<?> builder() {
         return new Builder<>();
@@ -178,29 +170,14 @@ public class ParticleQuad extends ParticleObject<ParticleQuad> {
 
     @Override
     public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
-
-        // Rotation
-        Quaternionfc quaternion =
-                new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
         // Defensive copy of `drawPos`
-        Vector3f totalOffset = new Vector3f(drawContext.getPosition()).add(this.offset);
-
-        Vector3f v1 = this.rigidTransformation(this.vertex1, quaternion, totalOffset);
-        Vector3f v2 = this.rigidTransformation(this.vertex2, quaternion, totalOffset);
-        Vector3f v3 = this.rigidTransformation(this.vertex3, quaternion, totalOffset);
-        Vector3f v4 = this.rigidTransformation(this.vertex4, quaternion, totalOffset);
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
 
         int step = drawContext.getCurrentStep();
-        renderer.drawLine(this.particleEffect, step, v1, v2, this.amount);
-        renderer.drawLine(this.particleEffect, step, v2, v3, this.amount);
-        renderer.drawLine(this.particleEffect, step, v3, v4, this.amount);
-        renderer.drawLine(this.particleEffect, step, v4, v1, this.amount);
-
-        // Provide the four vertices to the `afterDraw` method
-        drawContext.addMetadata(VERTEX_1, v1);
-        drawContext.addMetadata(VERTEX_2, v2);
-        drawContext.addMetadata(VERTEX_3, v3);
-        drawContext.addMetadata(VERTEX_4, v4);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex1, this.vertex2, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex2, this.vertex3, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex3, this.vertex4, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex4, this.vertex1, this.rotation, this.amount);
     }
 
     public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleQuad> {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
@@ -1,8 +1,6 @@
 package net.mcbrincie.apel.lib.objects;
 
 import net.mcbrincie.apel.lib.renderers.ApelServerRenderer;
-import org.joml.Quaternionf;
-import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 
 /** The particle object class that represents a tetrahedron which may be irregular.
@@ -178,26 +176,16 @@ public class ParticleTetrahedron extends ParticleObject<ParticleTetrahedron> {
 
     @Override
     public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
-
-        // Rotation
-        Quaternionfc quaternion =
-                new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
         // Defensive copy of `drawPos`
-        Vector3f totalOffset = new Vector3f(drawContext.getPosition()).add(this.offset);
-
-        // Defensive copies of internal vertices
-        Vector3f v1 = this.rigidTransformation(this.vertex1, quaternion, totalOffset);
-        Vector3f v2 = this.rigidTransformation(this.vertex2, quaternion, totalOffset);
-        Vector3f v3 = this.rigidTransformation(this.vertex3, quaternion, totalOffset);
-        Vector3f v4 = this.rigidTransformation(this.vertex4, quaternion, totalOffset);
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
 
         int step = drawContext.getCurrentStep();
-        renderer.drawLine(this.particleEffect, step, v1, v2, this.amount);
-        renderer.drawLine(this.particleEffect, step, v1, v3, this.amount);
-        renderer.drawLine(this.particleEffect, step, v1, v4, this.amount);
-        renderer.drawLine(this.particleEffect, step, v2, v3, this.amount);
-        renderer.drawLine(this.particleEffect, step, v2, v4, this.amount);
-        renderer.drawLine(this.particleEffect, step, v3, v4, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex1, this.vertex2, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex1, this.vertex3, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex1, this.vertex4, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex2, this.vertex3, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex2, this.vertex4, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex3, this.vertex4, this.rotation, this.amount);
     }
 
     public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleTetrahedron> {

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
@@ -150,22 +150,13 @@ public class ParticleTriangle extends ParticleObject<ParticleTriangle> {
 
     @Override
     public void draw(ApelServerRenderer renderer, DrawContext drawContext) {
-
-        // Rotation
-        Quaternionfc quaternion =
-                new Quaternionf().rotateZ(this.rotation.z).rotateY(this.rotation.y).rotateX(this.rotation.x);
         // Defensive copy of `drawPos`
-        Vector3f totalOffset = new Vector3f(drawContext.getPosition()).add(this.offset);
-
-        // Defensive copies of internal vertices
-        Vector3f v1 = this.rigidTransformation(this.vertex1, quaternion, totalOffset);
-        Vector3f v2 = this.rigidTransformation(this.vertex2, quaternion, totalOffset);
-        Vector3f v3 = this.rigidTransformation(this.vertex3, quaternion, totalOffset);
+        Vector3f objectDrawPos = new Vector3f(drawContext.getPosition()).add(this.offset);
 
         int step = drawContext.getCurrentStep();
-        renderer.drawLine(this.particleEffect, step, v1, v2, this.amount);
-        renderer.drawLine(this.particleEffect, step, v2, v3, this.amount);
-        renderer.drawLine(this.particleEffect, step, v3, v1, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex1, this.vertex2, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex2, this.vertex3, this.rotation, this.amount);
+        renderer.drawLine(this.particleEffect, step, objectDrawPos, this.vertex3, this.vertex1, this.rotation, this.amount);
     }
 
     public static class Builder<B extends Builder<B>> extends ParticleObject.Builder<B, ParticleTriangle> {

--- a/src/main/java/net/mcbrincie/apel/lib/renderers/ApelNetworkRenderer.java
+++ b/src/main/java/net/mcbrincie/apel/lib/renderers/ApelNetworkRenderer.java
@@ -54,12 +54,15 @@ public class ApelNetworkRenderer implements ApelServerRenderer {
      * @param step The step its currently in
      * @param start The 3D point at which to start
      * @param end The 3D point at which to end
-     * @param count The number of particles to draw along the line
+     * @param amount The number of particles to draw along the line
      */
     @Override
-    public void drawLine(ParticleEffect particleEffect, int step, Vector3f start, Vector3f end, int count) {
+    public void drawLine(
+            ParticleEffect particleEffect, int step, Vector3f drawPos, Vector3f start, Vector3f end, Vector3f rotation,
+            int amount
+    ) {
         this.detectParticleTypeChange(particleEffect);
-        this.instructions.add(new Line(start, end, count));
+        this.instructions.add(new Line(drawPos, start, end, rotation, amount));
     }
 
     @Override

--- a/src/main/java/net/mcbrincie/apel/lib/renderers/BaseApelRenderer.java
+++ b/src/main/java/net/mcbrincie/apel/lib/renderers/BaseApelRenderer.java
@@ -25,13 +25,18 @@ public abstract class BaseApelRenderer implements ApelRenderer {
     }
 
     @Override
-    public void drawLine(ParticleEffect particleEffect, int step, Vector3f start, Vector3f end, int amount) {
-        Instruction line = new Line(start, end, amount);
+    public void drawLine(
+            ParticleEffect particleEffect, int step, Vector3f drawPos, Vector3f start, Vector3f end, Vector3f rotation,
+            int amount
+    ) {
+        Instruction line = new Line(IGNORED_OFFSET, start, end, IGNORED_ROTATION, amount);
         Vector3f[] positions = this.positionsCache.computeIfAbsent(line, Instruction::computePoints);
 
-        // Lines do not rotate or translate
+        // Rotate and translate
+        Quaternionfc quaternion = new Quaternionf().rotateZ(rotation.z).rotateY(rotation.y).rotateX(rotation.x);
         for (Vector3f position : positions) {
-            drawParticle(particleEffect, step, position);
+            Vector3f pos = new Vector3f(position).rotate(quaternion).add(drawPos);
+            drawParticle(particleEffect, step, pos);
         }
     }
 


### PR DESCRIPTION
The BaseApelRenderer inefficiently cached ApelRenderer.Line instructions by caching every line after rotation and transformation.  For animations of reasonably complex models that move and rotate over several hundred steps, this quickly blows out the cache and subsequently the Java heap. This impacts all shapes that use `#drawLine`, since all of them rotated and translated prior to calling `#drawLine`.

To fix this, only cache the raw starting lines for any ParticleObject. This has the benefit of pre-computing the intermediate points on the starting lines, which allows for easy, quick rotation and transformation during later rendering steps.  This is a 1:N reduction in line point computation, which isn't terribly complex, but is very repetitive.

One "casualty" of this approach is that `ParticleQuad` no longer provides the modified vertices to its `afterDraw` interceptor.  No other shape did this, so it was a bit anomalous, but since `ParticleQuad` no longer knows the coordinates of the modified vertices, it cannot provide them to the interceptor.

This also removes `ParticleObject#rigidTransformation` because ParticleObject (and subclasses) no longer do any transformation; they only describe desired transformations: the renderers perform the mathematics to transform.