### PR TITLE
Triangle validity

### DIFF
--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedron.java
@@ -40,11 +40,12 @@ public class ParticleTetrahedron extends ParticleObject<ParticleTetrahedron> {
 
     private void checkValidTetrahedron(Vector3f vertex1, Vector3f vertex2, Vector3f vertex3, Vector3f vertex4) {
         // Defensive copies prior to subtraction and cross-product, which are done in-place.
-        Vector3f v1 = new Vector3f(vertex1);
-        Vector3f v2 = new Vector3f(vertex2);
-        Vector3f v3 = new Vector3f(vertex3);
-        Vector3f v4 = new Vector3f(vertex4);
-        float result = ((v2.sub(v1).cross(v3.sub(v1))).dot(v4.sub(v1)));
+        Vector3f v1 = new Vector3f(vertex2).sub(vertex1);
+        Vector3f v2 = new Vector3f(vertex3).sub(vertex1);
+        Vector3f v3 = new Vector3f(vertex4).sub(vertex1);
+        // This performs the scalar triple product, which calculates the volume of the parallelepiped formed by
+        // three vectors sharing an origin.  If any are co-planar, the volume is zero, and there is no tetrahedron.
+        float result = v1.cross(v2).dot(v3);
         if (Math.abs(result) < 0.0001f) {
             throw new IllegalArgumentException("Provided vertices do not produce a tetrahedron");
         }

--- a/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
+++ b/src/main/java/net/mcbrincie/apel/lib/objects/ParticleTriangle.java
@@ -41,9 +41,13 @@ public class ParticleTriangle extends ParticleObject<ParticleTriangle> {
     }
 
     private void checkValidTriangle(Vector3f vertex1, Vector3f vertex2, Vector3f vertex3) {
-        // Defensive copy before cross-product, which is done in-place.
-        float dotProduct1 = vertex3.dot(new Vector3f(vertex1).cross(vertex2));
-        if (dotProduct1 == 0) {
+        // Defensive copies prior to subtraction and cross-product, which are done in-place.
+        Vector3f v1 = new Vector3f(vertex2).sub(vertex1);
+        Vector3f v2 = new Vector3f(vertex3).sub(vertex1);
+        // As long as the vectors from vertex1->vertex2 and vertex1->vertex3 are not collinear, the triangle is valid.
+        // If they are collinear, the magnitude of the cross product vector will be zero (as will its square).
+        float crossProductMagnitudeSquared = v1.cross(v2).lengthSquared();
+        if (crossProductMagnitudeSquared == 0) {
             throw new IllegalArgumentException("Provided vertices do not produce a triangle");
         }
     }

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedronTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleTetrahedronTest.java
@@ -1,0 +1,43 @@
+package net.mcbrincie.apel.lib.objects;
+
+import net.minecraft.particle.ParticleEffect;
+import org.joml.Vector3f;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ParticleTetrahedronTest {
+    // Use this to prevent having to initialize all the Minecraft Server logic
+    private static final ParticleEffect NULL_PARTICLE = null;
+
+    @Test
+    void testValidTetrahedrons() {
+        // Irregular tetrahedron, should work
+        ParticleTetrahedron.builder()
+                .vertex1(new Vector3f(-2, 2, 1))
+                .vertex2(new Vector3f(2, 2, 1))
+                .vertex3(new Vector3f(0, 2, 5))
+                .vertex4(new Vector3f(1, 7, 4))
+                .build();
+
+        // All three base points at 3-4-5 triangle distances from origin, fourth point above, should work
+        ParticleTetrahedron.builder()
+                .vertex1(new Vector3f(-2.f, 2, -1.5f))
+                .vertex2(new Vector3f(2.f, 2, -1.5f))
+                .vertex3(new Vector3f(0.f, 2, 2.5f))
+                .vertex4(new Vector3f(0, 7, 0))
+                .build();
+    }
+
+    @Test
+    void testTetrahedronWithCoplanarVertices() {
+        // Four points of a square on the y=0 plane -- does not work because they're all co-planar
+        assertThrows(IllegalArgumentException.class,
+                () -> ParticleTetrahedron.builder()
+                        .vertex1(new Vector3f(1.f, 0, -1f))
+                        .vertex2(new Vector3f(1.f, 0, 1f))
+                        .vertex3(new Vector3f(-1.f, 0, 1f))
+                        .vertex4(new Vector3f(-1.f, 0, -1.f))
+                        .build());
+    }
+}

--- a/src/test/java/net/mcbrincie/apel/lib/objects/ParticleTriangleTest.java
+++ b/src/test/java/net/mcbrincie/apel/lib/objects/ParticleTriangleTest.java
@@ -1,0 +1,35 @@
+package net.mcbrincie.apel.lib.objects;
+
+import org.joml.Vector3f;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ParticleTriangleTest {
+
+    @Test
+    void testValidTriangles() {
+        // Triangle with point at origin, one-point on y-axis, and one point on x-axis
+        ParticleTriangle.builder()
+                .vertex1(new Vector3f(0))
+                .vertex2(new Vector3f(0, 1, 0))
+                .vertex3(new Vector3f(1, 0, 0))
+                .build();
+
+        // Triangle with less obvious points that are OK (this broke before the code fix)
+        ParticleTriangle.builder()
+                .vertex1(new Vector3f(2f))
+                .vertex2(new Vector3f(3f))
+                .vertex3(new Vector3f(1f, 4f, 6f))
+                .build();
+    }
+
+    @Test
+    void testCollinearPointsAreInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> ParticleTriangle.builder()
+                .vertex1(new Vector3f(0))
+                .vertex2(new Vector3f(1))
+                .vertex3(new Vector3f(4))
+                .build());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/GitBrincie212/Apel-Mod/issues/58.

Triangle validity just needs to check $||\vec{AB} \times \vec{AC}|| \neq 0$.  The scalar triple product $(\vec{AB} \times \vec{AC}) \cdot \vec{AD} \neq 0$ checks tetrahedron eligibility.

Write simple tests that validate these algorithms are correct.